### PR TITLE
Eco 738 - keyboard stays open after complete restore flow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.54
+SAMPLE_VERSION_NAME=0.0.55
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.1
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenterImpl.java
@@ -50,6 +50,7 @@ public class RestorePresenterImpl extends BasePresenterImpl<RestoreView> impleme
 				getView().navigateToEnterPassword((String) data);
 				break;
 			case STEP_RESTORE_COMPLETED:
+				getView().closeKeyboard();
 				getView().navigateToRestoreCompleted((Integer) data);
 				break;
 			case STEP_FINISH:

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
@@ -29,9 +29,9 @@ import com.kin.ecosystem.recovery.widget.PasswordEditText;
 public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnterPasswordView {
 
 	private static final String BUNDLE_KEY_KEYSTORE = "BUNDLE_KEY_KEYSTORE";
+	public static final int VIEW_MIN_DELAY_MILLIS = 50;
 	private RestoreEnterPasswordPresenter presenter;
 	private KeyboardHandler keyboardHandler;
-	private View root;
 	private Button doneBtn;
 	private TextView contentText;
 	private PasswordEditText password;
@@ -99,7 +99,6 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 	}
 
 	private void initViews(View root) {
-		this.root = root;
 		password = root.findViewById(R.id.kinrecovery_password_edit);
 		contentText = root.findViewById(R.id.kinrecovery_password_recovery_text);
 		doneBtn = root.findViewById(R.id.kinrecovery_password_recovery_btn);
@@ -116,7 +115,12 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 				presenter.onPasswordChanged(editable.toString());
 			}
 		}));
-		openKeyboard(password);
+		password.postDelayed(new Runnable() {
+			@Override
+			public void run() {
+				openKeyboard(password);
+			}
+		}, VIEW_MIN_DELAY_MILLIS);
 	}
 
 	private void openKeyboard(View view) {


### PR DESCRIPTION
#### Main purpose:
Close keyboard after complete restore flow.

* Also noticed that keyboard does not open on EnterPassword fragment due to system delay on getting view boundaries, so I added a minimum delay (otherwise it won't open).
