### PR TITLE
Solved crash after activity is killed for backup flow

### DIFF
--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupInfoPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupInfoPresenterImpl.java
@@ -4,20 +4,20 @@ package com.kin.ecosystem.recovery.backup.presenter;
 import static com.kin.ecosystem.recovery.events.EventDispatcherImpl.BACKUP_WELCOME_PAGE_VIEWED;
 
 import android.support.annotation.NonNull;
-import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
+import com.kin.ecosystem.recovery.backup.view.BackupNavigator;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
 import com.kin.ecosystem.recovery.base.BaseView;
 import com.kin.ecosystem.recovery.events.CallbackManager;
 
 public class BackupInfoPresenterImpl extends BasePresenterImpl<BaseView> implements BackupInfoPresenter {
 
-	private final BackupNextStepListener backupNextStepListener;
+	private final BackupNavigator backupNavigator;
 	private final CallbackManager callbackManager;
 
 	public BackupInfoPresenterImpl(@NonNull CallbackManager callbackManager,
-		BackupNextStepListener backupNextStepListener) {
+		BackupNavigator backupNavigator) {
 		this.callbackManager = callbackManager;
-		this.backupNextStepListener = backupNextStepListener;
+		this.backupNavigator = backupNavigator;
 	}
 
 	@Override
@@ -28,13 +28,13 @@ public class BackupInfoPresenterImpl extends BasePresenterImpl<BaseView> impleme
 
 	@Override
 	public void onBackClicked() {
-		backupNextStepListener.setStep(BackupNextStepListener.STEP_CLOSE, null);
+		backupNavigator.closeFlow();
 	}
 
 	@Override
 	public void letsGoButtonClicked() {
 		if (view != null) {
-			backupNextStepListener.setStep(BackupNextStepListener.STEP_CREATE_PASSWORD, null);
+			backupNavigator.navigateToCreatePasswordPage();
 		}
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupInfoPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupInfoPresenterImpl.java
@@ -14,7 +14,8 @@ public class BackupInfoPresenterImpl extends BasePresenterImpl<BaseView> impleme
 	private final BackupNextStepListener backupNextStepListener;
 	private final CallbackManager callbackManager;
 
-	public BackupInfoPresenterImpl(@NonNull CallbackManager callbackManager, BackupNextStepListener backupNextStepListener) {
+	public BackupInfoPresenterImpl(@NonNull CallbackManager callbackManager,
+		BackupNextStepListener backupNextStepListener) {
 		this.callbackManager = callbackManager;
 		this.backupNextStepListener = backupNextStepListener;
 	}

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenter.java
@@ -1,9 +1,13 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
 import com.kin.ecosystem.recovery.backup.view.BackupView;
 import com.kin.ecosystem.recovery.base.BasePresenter;
 
 public interface BackupPresenter extends BasePresenter<BackupView>, BackupNextStepListener {
 
+	void onSaveInstanceState(Bundle outState);
+
+	void saveKeyData(String key);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenter.java
@@ -1,13 +1,13 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
 import android.os.Bundle;
-import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
+import com.kin.ecosystem.recovery.backup.view.BackupNavigator;
 import com.kin.ecosystem.recovery.backup.view.BackupView;
 import com.kin.ecosystem.recovery.base.BasePresenter;
 
-public interface BackupPresenter extends BasePresenter<BackupView>, BackupNextStepListener {
+public interface BackupPresenter extends BasePresenter<BackupView>, BackupNavigator {
 
 	void onSaveInstanceState(Bundle outState);
 
-	void saveKeyData(String key);
+	void setAccountKey(String key);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/BackupPresenterImpl.java
@@ -2,6 +2,7 @@ package com.kin.ecosystem.recovery.backup.presenter;
 
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.kin.ecosystem.recovery.backup.view.BackupView;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
@@ -9,20 +10,30 @@ import com.kin.ecosystem.recovery.events.CallbackManager;
 
 public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implements BackupPresenter {
 
+	private static final String KEY_STEP = "kinrecovery_step";
+	public static final String KEY_ACCOUNT_KEY = "kinrecovery_account_key";
+
 	private @Step
-	int step = STEP_START;
+	int step;
 	private final CallbackManager callbackManager;
 	private boolean isBackupSucceed = false;
+	private final Bundle savedInstanceState;
 
 
-	public BackupPresenterImpl(CallbackManager callbackManager) {
+	public BackupPresenterImpl(CallbackManager callbackManager, @Nullable final Bundle savedInstanceState) {
 		this.callbackManager = callbackManager;
+		this.savedInstanceState = savedInstanceState != null ? savedInstanceState : new Bundle();
+		this.step = getStep();
+	}
+
+	private int getStep() {
+		return savedInstanceState != null ? savedInstanceState.getInt(KEY_STEP, STEP_START) : STEP_START;
 	}
 
 	@Override
 	public void onAttach(BackupView view) {
 		super.onAttach(view);
-		setStep(step, null);
+		setStep(step, savedInstanceState);
 	}
 
 	@Override
@@ -31,7 +42,7 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 			setStep(STEP_CLOSE, null);
 		} else {
 			if (view != null) {
-				if(!isBackupSucceed && step == STEP_CREATE_PASSWORD) {
+				if (!isBackupSucceed && step == STEP_CREATE_PASSWORD) {
 					callbackManager.sendCancelledResult();
 				}
 				step--;
@@ -53,11 +64,14 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 					break;
 				case STEP_SAVE_AND_SHARE:
 					if (data != null) {
-						final String key = data.getString(KEY_ACCOUNT_KEY, null);
+						final String key = getAccountKey(data);
 						view.moveToSaveAndSharePage(key);
+						isBackupSucceed = true;
+						callbackManager.sendBackupSuccessResult();
+					} else {
+						view.showError();
+						view.close();
 					}
-					isBackupSucceed = true;
-					callbackManager.sendBackupSuccessResult();
 					break;
 				case STEP_WELL_DONE:
 					view.moveToWellDonePage();
@@ -67,5 +81,20 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 					break;
 			}
 		}
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putInt(KEY_STEP, step);
+		outState.putString(KEY_ACCOUNT_KEY, getAccountKey(savedInstanceState));
+	}
+
+	@Override
+	public void saveKeyData(String key) {
+		this.savedInstanceState.putString(KEY_ACCOUNT_KEY, key);
+	}
+
+	private String getAccountKey(@NonNull final Bundle data) {
+		return data.getString(KEY_ACCOUNT_KEY);
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/CreatePasswordPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/CreatePasswordPresenterImpl.java
@@ -1,15 +1,11 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
 
-import static com.kin.ecosystem.recovery.backup.presenter.BackupPresenterImpl.KEY_ACCOUNT_KEY;
-import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_CLOSE;
-import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_SAVE_AND_SHARE;
 import static com.kin.ecosystem.recovery.events.EventDispatcherImpl.BACKUP_CREATE_PASSWORD_PAGE_VIEWED;
 
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.recovery.KeyStoreProvider;
-import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
+import com.kin.ecosystem.recovery.backup.view.BackupNavigator;
 import com.kin.ecosystem.recovery.backup.view.CreatePasswordView;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
 import com.kin.ecosystem.recovery.events.CallbackManager;
@@ -18,7 +14,7 @@ import com.kin.ecosystem.recovery.exception.BackupException;
 public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswordView> implements
 	CreatePasswordPresenter {
 
-	private final BackupNextStepListener backupNextStepListener;
+	private final BackupNavigator backupNavigator;
 	private final KeyStoreProvider keyStoreProvider;
 	private final CallbackManager callbackManager;
 	private boolean isPasswordRulesOK = false;
@@ -26,10 +22,9 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 	private boolean isIUnderstandChecked = false;
 
 	public CreatePasswordPresenterImpl(@NonNull final CallbackManager callbackManager,
-		@NonNull final BackupNextStepListener backupNextStepListener, @NonNull final
-	KeyStoreProvider keyStoreProvider) {
+		@NonNull final BackupNavigator backupNavigator, @NonNull final KeyStoreProvider keyStoreProvider) {
 		this.callbackManager = callbackManager;
-		this.backupNextStepListener = backupNextStepListener;
+		this.backupNavigator = backupNavigator;
 		this.keyStoreProvider = keyStoreProvider;
 	}
 
@@ -41,7 +36,7 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 
 	@Override
 	public void onBackClicked() {
-		backupNextStepListener.setStep(STEP_CLOSE, null);
+		backupNavigator.closeFlow();
 	}
 
 	@Override
@@ -109,10 +104,8 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 
 	private void exportAccount(String password) {
 		try {
-			final String key = keyStoreProvider.exportAccount(password);
-			final Bundle data = new Bundle();
-			data.putString(KEY_ACCOUNT_KEY, key);
-			backupNextStepListener.setStep(STEP_SAVE_AND_SHARE, data);
+			final String accountKey = keyStoreProvider.exportAccount(password);
+			backupNavigator.navigateToSaveAndSharePage(accountKey);
 		} catch (BackupException e) {
 			if (view != null) {
 				view.showBackupFailed();

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/CreatePasswordPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/CreatePasswordPresenterImpl.java
@@ -1,6 +1,7 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
-import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.KEY_ACCOUNT_KEY;
+
+import static com.kin.ecosystem.recovery.backup.presenter.BackupPresenterImpl.KEY_ACCOUNT_KEY;
 import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_CLOSE;
 import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_SAVE_AND_SHARE;
 import static com.kin.ecosystem.recovery.events.EventDispatcherImpl.BACKUP_CREATE_PASSWORD_PAGE_VIEWED;
@@ -12,7 +13,6 @@ import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
 import com.kin.ecosystem.recovery.backup.view.CreatePasswordView;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
 import com.kin.ecosystem.recovery.events.CallbackManager;
-import com.kin.ecosystem.recovery.events.EventDispatcherImpl;
 import com.kin.ecosystem.recovery.exception.BackupException;
 
 public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswordView> implements
@@ -25,7 +25,8 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 	private boolean isPasswordsMatches = false;
 	private boolean isIUnderstandChecked = false;
 
-	public CreatePasswordPresenterImpl(@NonNull final CallbackManager callbackManager, @NonNull final BackupNextStepListener backupNextStepListener, @NonNull final
+	public CreatePasswordPresenterImpl(@NonNull final CallbackManager callbackManager,
+		@NonNull final BackupNextStepListener backupNextStepListener, @NonNull final
 	KeyStoreProvider keyStoreProvider) {
 		this.callbackManager = callbackManager;
 		this.backupNextStepListener = backupNextStepListener;

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenter.java
@@ -1,5 +1,6 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.backup.view.SaveAndShareView;
 import com.kin.ecosystem.recovery.base.BasePresenter;
 
@@ -10,4 +11,6 @@ public interface SaveAndSharePresenter extends BasePresenter<SaveAndShareView> {
 	void sendQREmailClicked();
 
 	void couldNotLoadQRImage();
+
+	void onSaveInstanceState(Bundle outState);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenterImpl.java
@@ -1,11 +1,9 @@
 package com.kin.ecosystem.recovery.backup.presenter;
 
-import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_WELL_DONE;
-
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
+import com.kin.ecosystem.recovery.backup.view.BackupNavigator;
 import com.kin.ecosystem.recovery.backup.view.SaveAndShareView;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
 import com.kin.ecosystem.recovery.events.CallbackManager;
@@ -15,8 +13,8 @@ import com.kin.ecosystem.recovery.qr.QRBarcodeGenerator.QRBarcodeGeneratorExcept
 
 public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareView> implements SaveAndSharePresenter {
 
-	public static final String IS_SEND_EMAIL_CLICKED = "is_send_email_clicked";
-	private final BackupNextStepListener nextStepListener;
+	private static final String IS_SEND_EMAIL_CLICKED = "is_send_email_clicked";
+	private final BackupNavigator backupNavigator;
 	private final QRBarcodeGenerator qrBarcodeGenerator;
 	private final CallbackManager callbackManager;
 
@@ -25,10 +23,10 @@ public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareVie
 
 
 	public SaveAndSharePresenterImpl(@NonNull final CallbackManager callbackManager,
-		BackupNextStepListener nextStepListener,
+		BackupNavigator backupNavigator,
 		QRBarcodeGenerator qrBarcodeGenerator, String key, Bundle savedInstanceState) {
 		this.callbackManager = callbackManager;
-		this.nextStepListener = nextStepListener;
+		this.backupNavigator = backupNavigator;
 		this.qrBarcodeGenerator = qrBarcodeGenerator;
 		this.isSendQREmailClicked = getIsSendQrEmailClicked(savedInstanceState);
 		createQR(key);
@@ -70,7 +68,7 @@ public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareVie
 	@Override
 	public void iHaveSavedChecked(boolean isChecked) {
 		if (isChecked) {
-			nextStepListener.setStep(STEP_WELL_DONE, null);
+			backupNavigator.navigateToWellDonePage();
 		}
 	}
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/presenter/SaveAndSharePresenterImpl.java
@@ -3,6 +3,7 @@ package com.kin.ecosystem.recovery.backup.presenter;
 import static com.kin.ecosystem.recovery.backup.view.BackupNextStepListener.STEP_WELL_DONE;
 
 import android.net.Uri;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.recovery.backup.view.BackupNextStepListener;
 import com.kin.ecosystem.recovery.backup.view.SaveAndShareView;
@@ -14,19 +15,27 @@ import com.kin.ecosystem.recovery.qr.QRBarcodeGenerator.QRBarcodeGeneratorExcept
 
 public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareView> implements SaveAndSharePresenter {
 
+	public static final String IS_SEND_EMAIL_CLICKED = "is_send_email_clicked";
 	private final BackupNextStepListener nextStepListener;
 	private final QRBarcodeGenerator qrBarcodeGenerator;
 	private final CallbackManager callbackManager;
 
 	private Uri qrURI;
+	private boolean isSendQREmailClicked;
 
 
-	public SaveAndSharePresenterImpl(@NonNull final CallbackManager callbackManager, BackupNextStepListener nextStepListener, QRBarcodeGenerator qrBarcodeGenerator,
-		String key) {
+	public SaveAndSharePresenterImpl(@NonNull final CallbackManager callbackManager,
+		BackupNextStepListener nextStepListener,
+		QRBarcodeGenerator qrBarcodeGenerator, String key, Bundle savedInstanceState) {
 		this.callbackManager = callbackManager;
 		this.nextStepListener = nextStepListener;
 		this.qrBarcodeGenerator = qrBarcodeGenerator;
+		this.isSendQREmailClicked = getIsSendQrEmailClicked(savedInstanceState);
 		createQR(key);
+	}
+
+	private boolean getIsSendQrEmailClicked(Bundle savedInstanceState) {
+		return savedInstanceState != null && savedInstanceState.getBoolean(IS_SEND_EMAIL_CLICKED);
 	}
 
 	private void createQR(String key) {
@@ -41,6 +50,9 @@ public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareVie
 	public void onAttach(SaveAndShareView view) {
 		super.onAttach(view);
 		setQRImage();
+		if (isSendQREmailClicked && view != null) {
+			view.showIHaveSavedCheckBox();
+		}
 		callbackManager.sendBackupEvents(EventDispatcherImpl.BACKUP_QR_CODE_PAGE_VIEWED);
 	}
 
@@ -64,6 +76,7 @@ public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareVie
 
 	@Override
 	public void sendQREmailClicked() {
+		isSendQREmailClicked = true;
 		if (qrURI != null && view != null) {
 			view.showSendIntent(qrURI);
 			view.showIHaveSavedCheckBox();
@@ -75,5 +88,10 @@ public class SaveAndSharePresenterImpl extends BasePresenterImpl<SaveAndShareVie
 		if (view != null) {
 			view.showErrorTryAgainLater();
 		}
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putBoolean(IS_SEND_EMAIL_CLICKED, isSendQREmailClicked);
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
@@ -91,7 +91,7 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 		setNavigationIcon(R.drawable.kinrecovery_ic_back_black);
 		setToolbarTitle(R.string.kinrecovery_keep_your_kin_safe);
 		setStep(2, 2);
-		backupPresenter.saveKeyData(key);
+		backupPresenter.setAccountKey(key);
 		SaveAndShareFragment saveAndShareFragment = (SaveAndShareFragment) getSupportFragmentManager()
 			.findFragmentByTag(TAG_SAVE_AND_SHARE_PAGE);
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
@@ -1,11 +1,13 @@
 package com.kin.ecosystem.recovery.backup.view;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.widget.Toast;
 import com.kin.ecosystem.recovery.R;
 import com.kin.ecosystem.recovery.backup.presenter.BackupPresenter;
 import com.kin.ecosystem.recovery.backup.presenter.BackupPresenterImpl;
@@ -18,6 +20,9 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 
 	public static final String MOVE_TO_SAVE_AND_SHARE = "move_to_save_and_share";
 	public static final int TOOLBAR_COLOR_ANIM_DURATION = 500;
+	public static final String TAG_WELL_DONE_PAGE = WellDoneBackupFragment.class.getSimpleName();
+	public static final String TAG_SAVE_AND_SHARE_PAGE = SaveAndShareFragment.class.getSimpleName();
+	public static final String TAG_CREATE_PASSWORD_PAGE = CreatePasswordFragment.class.getSimpleName();
 	private BackupPresenter backupPresenter;
 
 	@Override
@@ -28,7 +33,8 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 	@Override
 	protected void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		backupPresenter = new BackupPresenterImpl(new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(this))));
+		backupPresenter = new BackupPresenterImpl(
+			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(this))), savedInstanceState);
 		backupPresenter.onAttach(this);
 		setNavigationClickListener(new OnClickListener() {
 			@Override
@@ -36,6 +42,12 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 				backupPresenter.onBackClicked();
 			}
 		});
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		backupPresenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override
@@ -48,6 +60,8 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 
 		if (backupInfoFragment == null) {
 			backupInfoFragment = BackupInfoFragment.newInstance(backupPresenter);
+		} else {
+			backupInfoFragment.setNextStepListener(backupPresenter);
 		}
 
 		getSupportFragmentManager().beginTransaction()
@@ -61,27 +75,34 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 		setNavigationIcon(R.drawable.kinrecovery_ic_back_black);
 		setToolbarTitle(R.string.kinrecovery_keep_your_kin_safe);
 		setStep(1, 2);
-		CreatePasswordFragment createPasswordFragment = (CreatePasswordFragment) getSupportFragmentManager()
-			.findFragmentByTag(CreatePasswordFragment.class.getSimpleName());
+		CreatePasswordFragment createPasswordFragment = getSavedCreatePasswordFragment();
 
 		if (createPasswordFragment == null) {
 			createPasswordFragment = CreatePasswordFragment.newInstance(backupPresenter, this);
+		} else {
+			setCreatePasswordFragmentAttributes(createPasswordFragment);
 		}
 
-		replaceFragment(createPasswordFragment, null);
+		replaceFragment(createPasswordFragment, null, TAG_CREATE_PASSWORD_PAGE);
 	}
 
 	@Override
 	public void moveToSaveAndSharePage(String key) {
+		setNavigationIcon(R.drawable.kinrecovery_ic_back_black);
+		setToolbarTitle(R.string.kinrecovery_keep_your_kin_safe);
 		setStep(2, 2);
+		backupPresenter.saveKeyData(key);
 		SaveAndShareFragment saveAndShareFragment = (SaveAndShareFragment) getSupportFragmentManager()
-			.findFragmentByTag(SaveAndShareFragment.class.getSimpleName());
+			.findFragmentByTag(TAG_SAVE_AND_SHARE_PAGE);
 
 		if (saveAndShareFragment == null) {
 			saveAndShareFragment = SaveAndShareFragment.newInstance(backupPresenter, key);
+			replaceFragment(saveAndShareFragment, MOVE_TO_SAVE_AND_SHARE, TAG_SAVE_AND_SHARE_PAGE);
+		} else {
+			saveAndShareFragment.setNextStepListener(backupPresenter);
+			// We should not add to back stack because it's already in stack.
+			replaceFragment(saveAndShareFragment, null, TAG_SAVE_AND_SHARE_PAGE);
 		}
-
-		replaceFragment(saveAndShareFragment, MOVE_TO_SAVE_AND_SHARE);
 	}
 
 	@Override
@@ -91,23 +112,23 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 		setToolbarTitle(EMPTY_TITLE);
 		clearSteps();
 		WellDoneBackupFragment wellDoneFragment = (WellDoneBackupFragment) getSupportFragmentManager()
-			.findFragmentByTag(WellDoneBackupFragment.class.getSimpleName());
+			.findFragmentByTag(TAG_WELL_DONE_PAGE);
 
 		if (wellDoneFragment == null) {
 			wellDoneFragment = WellDoneBackupFragment.newInstance();
 		}
 
-		replaceFragment(wellDoneFragment, null);
+		replaceFragment(wellDoneFragment, null, TAG_WELL_DONE_PAGE);
 	}
 
-	private void replaceFragment(Fragment backupFragment, @Nullable String backStackName) {
+	private void replaceFragment(Fragment backupFragment, @Nullable String backStackName, @NonNull String tag) {
 		FragmentTransaction transaction = getSupportFragmentManager().beginTransaction()
 			.setCustomAnimations(
 				R.anim.kinrecovery_slide_in_right,
 				R.anim.kinrecovery_slide_out_left,
 				R.anim.kinrecovery_slide_in_left,
 				R.anim.kinrecovery_slide_out_right)
-			.replace(R.id.fragment_frame, backupFragment);
+			.replace(R.id.fragment_frame, backupFragment, tag);
 
 		if (backStackName != null) {
 			transaction.addToBackStack(backStackName);
@@ -124,6 +145,11 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 	}
 
 	@Override
+	public void showError() {
+		Toast.makeText(this, R.string.kinrecovery_something_went_wrong_title, Toast.LENGTH_SHORT).show();
+	}
+
+	@Override
 	public void onBackPressed() {
 		backupPresenter.onBackClicked();
 	}
@@ -137,10 +163,28 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 	@Override
 	public void onBackButtonClicked() {
 		int count = getSupportFragmentManager().getBackStackEntryCount();
+		if (count == 1) {
+			// After pressing back from SaveAndShareFragment, should put the attrs again.
+			// Because this is the only fragment that should be in stack.
+			CreatePasswordFragment createPasswordFragment = getSavedCreatePasswordFragment();
+			if (createPasswordFragment != null) {
+				setCreatePasswordFragmentAttributes(createPasswordFragment);
+			}
+		}
 		super.onBackPressed();
 		if (count == 0) {
 			closeKeyboard(); // Verify the keyboard is hidden
 			overridePendingTransition(0, R.anim.kinrecovery_slide_out_right);
 		}
+	}
+
+	private void setCreatePasswordFragmentAttributes(CreatePasswordFragment createPasswordFragment) {
+		createPasswordFragment.setNextStepListener(backupPresenter);
+		createPasswordFragment.setKeyboardHandler(this);
+	}
+
+	private CreatePasswordFragment getSavedCreatePasswordFragment() {
+		return (CreatePasswordFragment) getSupportFragmentManager()
+			.findFragmentByTag(TAG_CREATE_PASSWORD_PAGE);
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupInfoFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupInfoFragment.java
@@ -18,13 +18,13 @@ import com.kin.ecosystem.recovery.events.EventDispatcherImpl;
 
 public class BackupInfoFragment extends Fragment implements BaseView {
 
-	public static BackupInfoFragment newInstance(@NonNull final BackupNextStepListener nextStepListener) {
+	public static BackupInfoFragment newInstance(@NonNull final BackupNavigator nextStepListener) {
 		BackupInfoFragment fragment = new BackupInfoFragment();
 		fragment.setNextStepListener(nextStepListener);
 		return fragment;
 	}
 
-	private BackupNextStepListener nextStepListener;
+	private BackupNavigator nextStepListener;
 	private BackupInfoPresenter backupInfoPresenter;
 
 
@@ -49,7 +49,7 @@ public class BackupInfoFragment extends Fragment implements BaseView {
 		});
 	}
 
-	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNavigator nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupInfoFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupInfoFragment.java
@@ -49,7 +49,7 @@ public class BackupInfoFragment extends Fragment implements BaseView {
 		});
 	}
 
-	private void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupNavigator.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupNavigator.java
@@ -1,12 +1,11 @@
 package com.kin.ecosystem.recovery.backup.view;
 
-import android.os.Bundle;
 import android.support.annotation.IntDef;
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-public interface BackupNextStepListener {
+public interface BackupNavigator {
 
 	int STEP_START = 0x00000000;
 	int STEP_CREATE_PASSWORD = 0x00000001;
@@ -21,5 +20,12 @@ public interface BackupNextStepListener {
 
 	}
 
-	void setStep(@Step final int step, @Nullable final Bundle data);
+	void navigateToCreatePasswordPage();
+
+	void navigateToSaveAndSharePage(@NonNull String accountKey);
+
+	void navigateToWellDonePage();
+
+	void closeFlow();
+
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupNextStepListener.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupNextStepListener.java
@@ -21,7 +21,5 @@ public interface BackupNextStepListener {
 
 	}
 
-	String KEY_ACCOUNT_KEY = "kinrecovery_account_key";
-
 	void setStep(@Step final int step, @Nullable final Bundle data);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupView.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupView.java
@@ -16,4 +16,6 @@ public interface BackupView extends BaseView, KeyboardHandler {
 	void moveToWellDonePage();
 
 	void close();
+
+	void showError();
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/CreatePasswordFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/CreatePasswordFragment.java
@@ -126,11 +126,11 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 		confirmPassEditText.setFrameBackgroundColor(R.color.kinrecovery_gray);
 	}
 
-	private void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 
-	private void setKeyboardHandler(KeyboardHandler keyboardHandler) {
+	public void setKeyboardHandler(KeyboardHandler keyboardHandler) {
 		this.keyboardHandler = keyboardHandler;
 	}
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/CreatePasswordFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/CreatePasswordFragment.java
@@ -28,7 +28,7 @@ import com.kin.ecosystem.recovery.widget.PasswordEditText;
 
 public class CreatePasswordFragment extends Fragment implements CreatePasswordView {
 
-	public static CreatePasswordFragment newInstance(@NonNull final BackupNextStepListener nextStepListener,
+	public static CreatePasswordFragment newInstance(@NonNull final BackupNavigator nextStepListener,
 		@NonNull final KeyboardHandler keyboardHandler) {
 		CreatePasswordFragment fragment = new CreatePasswordFragment();
 		fragment.setNextStepListener(nextStepListener);
@@ -36,7 +36,7 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 		return fragment;
 	}
 
-	private BackupNextStepListener nextStepListener;
+	private BackupNavigator nextStepListener;
 	private KeyboardHandler keyboardHandler;
 	private CreatePasswordPresenter createPasswordPresenter;
 
@@ -126,7 +126,7 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 		confirmPassEditText.setFrameBackgroundColor(R.color.kinrecovery_gray);
 	}
 
-	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNavigator nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/SaveAndShareFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/SaveAndShareFragment.java
@@ -1,5 +1,7 @@
 package com.kin.ecosystem.recovery.backup.view;
 
+import static com.kin.ecosystem.recovery.backup.presenter.BackupPresenterImpl.KEY_ACCOUNT_KEY;
+
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -35,8 +37,6 @@ import java.util.TimeZone;
 
 public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 
-	public static final String KEY_ACCOUNT_KEY = "key_account_key";
-
 	public static SaveAndShareFragment newInstance(BackupNextStepListener listener, String key) {
 		SaveAndShareFragment fragment = new SaveAndShareFragment();
 		fragment.setNextStepListener(listener);
@@ -64,7 +64,7 @@ public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 			new QRFileUriHandlerImpl(getContext()));
 		saveAndSharePresenter = new SaveAndSharePresenterImpl(
 			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(getActivity()))), nextStepListener,
-			qrBarcodeGenerator, key);
+			qrBarcodeGenerator, key, savedInstanceState);
 		saveAndSharePresenter.onAttach(this);
 		return root;
 	}
@@ -97,6 +97,12 @@ public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 	}
 
 	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		saveAndSharePresenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
+	}
+
+	@Override
 	public void showIHaveSavedCheckBox() {
 		iHaveSavedCheckbox.setVisibility(View.VISIBLE);
 		iHaveSavedText.setVisibility(View.VISIBLE);
@@ -112,7 +118,7 @@ public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 			.show();
 	}
 
-	private void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/SaveAndShareFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/SaveAndShareFragment.java
@@ -37,7 +37,7 @@ import java.util.TimeZone;
 
 public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 
-	public static SaveAndShareFragment newInstance(BackupNextStepListener listener, String key) {
+	public static SaveAndShareFragment newInstance(BackupNavigator listener, String key) {
 		SaveAndShareFragment fragment = new SaveAndShareFragment();
 		fragment.setNextStepListener(listener);
 		Bundle bundle = new Bundle();
@@ -46,7 +46,7 @@ public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 		return fragment;
 	}
 
-	private BackupNextStepListener nextStepListener;
+	private BackupNavigator nextStepListener;
 	private SaveAndSharePresenter saveAndSharePresenter;
 
 	private CheckBox iHaveSavedCheckbox;
@@ -118,7 +118,7 @@ public class SaveAndShareFragment extends Fragment implements SaveAndShareView {
 			.show();
 	}
 
-	public void setNextStepListener(@NonNull final BackupNextStepListener nextStepListener) {
+	public void setNextStepListener(@NonNull final BackupNavigator nextStepListener) {
 		this.nextStepListener = nextStepListener;
 	}
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/WellDoneBackupFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/WellDoneBackupFragment.java
@@ -24,7 +24,8 @@ public class WellDoneBackupFragment extends Fragment {
 	public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
 		@Nullable Bundle savedInstanceState) {
 		View root = inflater.inflate(R.layout.kinrecovery_fragment_well_done_backup, container, false);
-		final CallbackManager callbackManager = new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(getActivity())));
+		final CallbackManager callbackManager = new CallbackManager(
+			new EventDispatcherImpl(new BroadcastManagerImpl(getActivity())));
 		callbackManager.sendBackupEvents(BACKUP_COMPLETED_PAGE_VIEWED);
 		return root;
 	}

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/base/BaseToolbarActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/base/BaseToolbarActivity.java
@@ -6,6 +6,7 @@ import android.animation.ValueAnimator.AnimatorUpdateListener;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
@@ -24,6 +25,7 @@ import com.kin.ecosystem.recovery.R;
 public abstract class BaseToolbarActivity extends AppCompatActivity implements KeyboardHandler {
 
 	public static final int EMPTY_TITLE = -1;
+	public static final String BACKGROUND_COLOR = "background_color";
 
 	protected abstract @LayoutRes
 	int getContentLayout();
@@ -36,12 +38,34 @@ public abstract class BaseToolbarActivity extends AppCompatActivity implements K
 	protected void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(getContentLayout());
-		setupToolbar();
+		setupToolbar(savedInstanceState);
 	}
 
-	private void setupToolbar() {
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		saveToolbarBackgroundColor(outState);
+		super.onSaveInstanceState(outState);
+
+	}
+
+	private void saveToolbarBackgroundColor(Bundle outState) {
+		ColorDrawable colorDrawable = ((ColorDrawable) topToolBar.getBackground());
+		if (colorDrawable != null) {
+			outState.putInt(BACKGROUND_COLOR, colorDrawable.getColor());
+		}
+	}
+
+	private void setupToolbar(Bundle savedInstanceState) {
 		topToolBar = findViewById(R.id.toolbar);
+		int color = getColorFromBundle(savedInstanceState);
+		topToolBar.setBackgroundColor(color);
 		setSupportActionBar(topToolBar);
+	}
+
+	private int getColorFromBundle(Bundle savedInstanceState) {
+		final int defaultColor = ContextCompat.getColor(getApplicationContext(), R.color.kinrecovery_white);
+		return savedInstanceState != null ? savedInstanceState
+			.getInt(BACKGROUND_COLOR, defaultColor) : defaultColor;
 	}
 
 	public void setToolbarTitle(@StringRes int titleRes) {


### PR DESCRIPTION
#### Main purpose:
The crash appeared while having the developer option of `don't keep activities`.
This fix is only for backup flow, restore flow will do next.
#### Technical description:
Add save instance state mechanism for the fragments and main activity `BackupActivity`

