### PR TITLE
Eco 744/kill activities restore flow crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.55
+SAMPLE_VERSION_NAME=0.0.56
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.1
 

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/backup/view/BackupActivity.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentManager.BackStackEntry;
 import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -163,12 +165,15 @@ public class BackupActivity extends BaseToolbarActivity implements BackupView {
 	@Override
 	public void onBackButtonClicked() {
 		int count = getSupportFragmentManager().getBackStackEntryCount();
-		if (count == 1) {
-			// After pressing back from SaveAndShareFragment, should put the attrs again.
-			// Because this is the only fragment that should be in stack.
-			CreatePasswordFragment createPasswordFragment = getSavedCreatePasswordFragment();
-			if (createPasswordFragment != null) {
-				setCreatePasswordFragmentAttributes(createPasswordFragment);
+		if(count >= 1) {
+			BackStackEntry entry = getSupportFragmentManager().getBackStackEntryAt(count - 1);
+			if (entry.getName().equals(MOVE_TO_SAVE_AND_SHARE)) {
+				// After pressing back from SaveAndShareFragment, should put the attrs again.
+				// Because this is the only fragment that should be in stack.
+				CreatePasswordFragment createPasswordFragment = getSavedCreatePasswordFragment();
+				if (createPasswordFragment != null) {
+					setCreatePasswordFragmentAttributes(createPasswordFragment);
+				}
 			}
 		}
 		super.onBackPressed();

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreCompletedPresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreCompletedPresenter.java
@@ -1,9 +1,12 @@
 package com.kin.ecosystem.recovery.restore.presenter;
 
 
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.restore.view.RestoreCompletedView;
 
 public interface RestoreCompletedPresenter extends BaseChildPresenter<RestoreCompletedView> {
 
-	void finish();
+	void close();
+
+	void onSaveInstanceState(Bundle outState);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreCompletedPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreCompletedPresenterImpl.java
@@ -1,15 +1,18 @@
 package com.kin.ecosystem.recovery.restore.presenter;
 
 
+import static com.kin.ecosystem.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_INDEX;
+
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.restore.view.RestoreCompletedView;
 
 public class RestoreCompletedPresenterImpl extends BaseChildPresenterImpl<RestoreCompletedView> implements
 	RestoreCompletedPresenter {
 
-	private final int accountId;
+	private final int accountIndex;
 
-	public RestoreCompletedPresenterImpl(int accountId) {
-		this.accountId = accountId;
+	public RestoreCompletedPresenterImpl(int accountIndex) {
+		this.accountIndex = accountIndex;
 	}
 
 	@Override
@@ -23,7 +26,12 @@ public class RestoreCompletedPresenterImpl extends BaseChildPresenterImpl<Restor
 	}
 
 	@Override
-	public void finish() {
-		getParentPresenter().nextStep(accountId);
+	public void close() {
+		getParentPresenter().closeFlow(accountIndex);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putInt(KEY_ACCOUNT_INDEX, accountIndex);
 	}
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreEnterPasswordPresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreEnterPasswordPresenter.java
@@ -1,6 +1,7 @@
 package com.kin.ecosystem.recovery.restore.presenter;
 
 
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.restore.view.RestoreEnterPasswordView;
 
 public interface RestoreEnterPasswordPresenter extends BaseChildPresenter<RestoreEnterPasswordView> {
@@ -9,4 +10,5 @@ public interface RestoreEnterPasswordPresenter extends BaseChildPresenter<Restor
 
 	void restoreClicked(String password);
 
+	void onSaveInstanceState(Bundle outState);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreEnterPasswordPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestoreEnterPasswordPresenterImpl.java
@@ -3,12 +3,13 @@ package com.kin.ecosystem.recovery.restore.presenter;
 
 import static com.kin.ecosystem.recovery.events.EventDispatcherImpl.RESTORE_PASSWORD_DONE_TAPPED;
 import static com.kin.ecosystem.recovery.events.EventDispatcherImpl.RESTORE_PASSWORD_ENTRY_PAGE_VIEWED;
+import static com.kin.ecosystem.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_KEY;
 
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.recovery.BackupManager;
 import com.kin.ecosystem.recovery.KeyStoreProvider;
 import com.kin.ecosystem.recovery.events.CallbackManager;
-import com.kin.ecosystem.recovery.events.EventDispatcherImpl;
 import com.kin.ecosystem.recovery.exception.BackupException;
 import com.kin.ecosystem.recovery.restore.view.RestoreEnterPasswordView;
 import com.kin.ecosystem.recovery.utils.Logger;
@@ -45,7 +46,7 @@ public class RestoreEnterPasswordPresenterImpl extends BaseChildPresenterImpl<Re
 		KeyStoreProvider keyStoreProvider = BackupManager.getKeyStoreProvider();
 		try {
 			int accountIndex = keyStoreProvider.importAccount(keystoreData, password);
-			getParentPresenter().nextStep(accountIndex);
+			getParentPresenter().navigateToRestoreCompletedPage(accountIndex);
 		} catch (BackupException e) {
 			Logger.e("RestoreEnterPasswordPresenterImpl - restore failed.", e);
 			if (e.getCode() == BackupException.CODE_RESTORE_INVALID_KEYSTORE_FORMAT) {
@@ -54,6 +55,11 @@ public class RestoreEnterPasswordPresenterImpl extends BaseChildPresenterImpl<Re
 				getView().decodeError();
 			}
 		}
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putString(KEY_ACCOUNT_KEY, keystoreData);
 	}
 
 	@Override

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenter.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenter.java
@@ -2,16 +2,21 @@ package com.kin.ecosystem.recovery.restore.presenter;
 
 
 import android.content.Intent;
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.base.BasePresenter;
 import com.kin.ecosystem.recovery.restore.view.RestoreView;
 
 public interface RestorePresenter extends BasePresenter<RestoreView> {
 
-	void nextStep();
+	void navigateToEnterPasswordPage(final String accountKey);
 
-	void nextStep(Object data);
+	void navigateToRestoreCompletedPage(final int accountIndex);
+
+	void closeFlow(final int accountIndex);
 
 	void previousStep();
 
 	void onActivityResult(int requestCode, int resultCode, Intent data);
+
+	void onSaveInstanceState(Bundle outState);
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/RestorePresenterImpl.java
@@ -2,31 +2,52 @@ package com.kin.ecosystem.recovery.restore.presenter;
 
 
 import android.content.Intent;
+import android.os.Bundle;
 import com.kin.ecosystem.recovery.base.BasePresenterImpl;
 import com.kin.ecosystem.recovery.events.CallbackManager;
 import com.kin.ecosystem.recovery.restore.view.RestoreView;
 
 public class RestorePresenterImpl extends BasePresenterImpl<RestoreView> implements RestorePresenter {
 
-	private static final int STEP_INITIAL = 0;
-	private static final int STEP_UPLOAD = 1;
-	private static final int STEP_ENTER_PASSWORD = 2;
-	private static final int STEP_RESTORE_COMPLETED = 3;
-	private static final int STEP_FINISH = 4;
+	private static final int STEP_UPLOAD = 0;
+	static final int STEP_ENTER_PASSWORD = 1;
+	static final int STEP_RESTORE_COMPLETED = 2;
+	static final int STEP_FINISH = 3;
 
-	private int currentStep = 0;
+	private static final String KEY_RESTORE_STEP = "kinrecovery_restore_step";
+	public static final String KEY_ACCOUNT_KEY = "kinrecovery_restore_account_key";
+	public static final String KEY_ACCOUNT_INDEX = "kinrecovery_restore_account_index";
+
+	private int currentStep;
+	private String accountKey;
+	private int accountIndex;
 
 	private final CallbackManager callbackManager;
 
-	public RestorePresenterImpl(CallbackManager callbackManager) {
+	public RestorePresenterImpl(CallbackManager callbackManager, Bundle saveInstanceState) {
 		this.callbackManager = callbackManager;
+		this.currentStep = getStep(saveInstanceState);
+		this.accountKey = getAccountKey(saveInstanceState);
+		this.accountIndex = getAccountIndex(saveInstanceState);
 	}
+
 
 	@Override
 	public void onAttach(RestoreView view) {
 		super.onAttach(view);
-		currentStep = STEP_INITIAL;
-		nextStep();
+		switchToStep(currentStep);
+	}
+
+	private int getStep(Bundle saveInstanceState) {
+		return saveInstanceState != null ? saveInstanceState.getInt(KEY_RESTORE_STEP, STEP_UPLOAD) : STEP_UPLOAD;
+	}
+
+	private String getAccountKey(Bundle saveInstanceState) {
+		return saveInstanceState != null ? saveInstanceState.getString(KEY_ACCOUNT_KEY) : null;
+	}
+
+	private int getAccountIndex(Bundle saveInstanceState) {
+		return saveInstanceState != null ? saveInstanceState.getInt(KEY_ACCOUNT_INDEX) : -1;
 	}
 
 	@Override
@@ -34,31 +55,56 @@ public class RestorePresenterImpl extends BasePresenterImpl<RestoreView> impleme
 		previousStep();
 	}
 
-	@Override
-	public void nextStep() {
-		nextStep(null);
-	}
-
-	@Override
-	public void nextStep(Object data) {
-		currentStep++;
-		switch (currentStep) {
+	private void switchToStep(int step) {
+		currentStep = step;
+		switch (step) {
 			case STEP_UPLOAD:
 				getView().navigateToUpload();
 				break;
 			case STEP_ENTER_PASSWORD:
-				getView().navigateToEnterPassword((String) data);
+				if (accountKey != null) {
+					getView().navigateToEnterPassword(accountKey);
+				} else {
+					getView().showError();
+				}
 				break;
 			case STEP_RESTORE_COMPLETED:
 				getView().closeKeyboard();
-				getView().navigateToRestoreCompleted((Integer) data);
+				if (accountIndex != -1) {
+					getView().navigateToRestoreCompleted(accountIndex);
+				} else {
+					getView().showError();
+				}
 				break;
 			case STEP_FINISH:
-				callbackManager.sendRestoreSuccessResult((Integer) data);
+				if (accountIndex != -1) {
+					callbackManager.sendRestoreSuccessResult(accountIndex);
+				} else {
+					getView().showError();
+				}
 				getView().close();
 				break;
 		}
 	}
+
+	@Override
+	public void navigateToEnterPasswordPage(final String accountKey) {
+		this.accountKey = accountKey;
+		switchToStep(STEP_ENTER_PASSWORD);
+	}
+
+	@Override
+	public void navigateToRestoreCompletedPage(final int accountIndex) {
+		this.accountIndex = accountIndex;
+		switchToStep(STEP_RESTORE_COMPLETED);
+	}
+
+	@Override
+	public void closeFlow(final int accountIndex) {
+		this.accountIndex = accountIndex;
+		switchToStep(STEP_FINISH);
+	}
+
 
 	@Override
 	public void previousStep() {
@@ -84,6 +130,13 @@ public class RestorePresenterImpl extends BasePresenterImpl<RestoreView> impleme
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
 		callbackManager.onActivityResult(requestCode, resultCode, data);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putInt(KEY_RESTORE_STEP, currentStep);
+		outState.putString(KEY_ACCOUNT_KEY, accountKey);
+		outState.putInt(KEY_ACCOUNT_INDEX, accountIndex);
 	}
 
 }

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/UploadQRPresenterImpl.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/presenter/UploadQRPresenterImpl.java
@@ -9,7 +9,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.recovery.events.CallbackManager;
-import com.kin.ecosystem.recovery.events.EventDispatcherImpl;
 import com.kin.ecosystem.recovery.qr.QRBarcodeGenerator;
 import com.kin.ecosystem.recovery.qr.QRBarcodeGenerator.QRBarcodeGeneratorException;
 import com.kin.ecosystem.recovery.qr.QRBarcodeGenerator.QRFileHandlingException;
@@ -70,7 +69,7 @@ public class UploadQRPresenterImpl extends BaseChildPresenterImpl<UploadQRView> 
 	private void loadEncryptedKeyStore(Uri fileUri) {
 		try {
 			String encryptedKeyStore = qrBarcodeGenerator.decodeQR(fileUri);
-			getParentPresenter().nextStep(encryptedKeyStore);
+			getParentPresenter().navigateToEnterPasswordPage(encryptedKeyStore);
 		} catch (QRFileHandlingException e) {
 			Logger.e("loadEncryptedKeyStore - loading file failed.", e);
 			view.showErrorLoadingFileDialog();

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager.BackStackEntry;
 import android.support.v4.app.FragmentTransaction;
 import android.widget.Toast;
 import com.kin.ecosystem.recovery.R;
@@ -30,6 +31,12 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 	protected void onSaveInstanceState(Bundle outState) {
 		presenter.onSaveInstanceState(outState);
 		super.onSaveInstanceState(outState);
+	}
+
+	@Override
+	protected void onStop() {
+		super.onStop();
+		closeKeyboard();
 	}
 
 	@Override
@@ -104,12 +111,15 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 	@Override
 	public void navigateBack() {
 		int count = getSupportFragmentManager().getBackStackEntryCount();
-		if (count == 3) {
-			// After pressing back from RestoreCompletedPage, should put the attrs again.
-			// This is the only fragment that should set arguments again on back.
-			RestoreEnterPasswordFragment enterPasswordFragment = getSavedRestoreEnterPasswordFragment();
-			if (enterPasswordFragment != null) {
-				enterPasswordFragment.setKeyboardHandler(this);
+		if(count >= 1) {
+			BackStackEntry entry = getSupportFragmentManager().getBackStackEntryAt(count - 1);
+			if (entry.getName().equals(RestoreEnterPasswordFragment.class.getSimpleName())) {
+				// After pressing back from RestoreCompletedPage, should put the attrs again.
+				// This is the only fragment that should set arguments again on back.
+				RestoreEnterPasswordFragment enterPasswordFragment = getSavedRestoreEnterPasswordFragment();
+				if (enterPasswordFragment != null) {
+					enterPasswordFragment.setKeyboardHandler(this);
+				}
 			}
 		}
 		super.onBackPressed();

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
@@ -55,8 +55,7 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 	@Override
 	public void navigateToEnterPassword(String keystoreData) {
 		final String fragmentName = RestoreEnterPasswordFragment.class.getSimpleName();
-		RestoreEnterPasswordFragment fragment = (RestoreEnterPasswordFragment) getSupportFragmentManager()
-			.findFragmentByTag(fragmentName);
+		RestoreEnterPasswordFragment fragment = getSavedRestoreEnterPasswordFragment();
 
 		if (fragment == null) {
 			fragment = RestoreEnterPasswordFragment.newInstance(keystoreData, this);
@@ -85,8 +84,7 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 
 	private void replaceFragment(Fragment fragment, String backStackName, String tag, boolean addAnimation) {
 		FragmentTransaction transaction = getSupportFragmentManager()
-			.beginTransaction()
-			.replace(R.id.fragment_frame, fragment, tag);
+			.beginTransaction();
 
 		if (backStackName != null) {
 			transaction.addToBackStack(backStackName);
@@ -94,12 +92,13 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 
 		if (addAnimation) {
 			transaction.setCustomAnimations(
-				R.anim.kinrecovery_slide_in_right,
-				R.anim.kinrecovery_slide_out_left,
+				0,
+				0,
 				R.anim.kinrecovery_slide_in_left,
 				R.anim.kinrecovery_slide_out_right);
 		}
-		transaction.commit();
+
+		transaction.replace(R.id.fragment_frame, fragment, tag).commit();
 	}
 
 	@Override
@@ -113,7 +112,7 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 				enterPasswordFragment.setKeyboardHandler(this);
 			}
 		}
-		getSupportFragmentManager().popBackStack(null, 0);
+		super.onBackPressed();
 	}
 
 	private RestoreEnterPasswordFragment getSavedRestoreEnterPasswordFragment() {

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.widget.Toast;
 import com.kin.ecosystem.recovery.R;
 import com.kin.ecosystem.recovery.base.BaseToolbarActivity;
 import com.kin.ecosystem.recovery.events.BroadcastManagerImpl;
@@ -16,15 +17,19 @@ import com.kin.ecosystem.recovery.restore.presenter.RestorePresenterImpl;
 public class RestoreActivity extends BaseToolbarActivity implements RestoreView {
 
 	private RestorePresenter presenter;
-	private String backStackName;
 
 	@Override
 	protected void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
 		presenter = new RestorePresenterImpl(
-			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(this))));
+			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(this))), savedInstanceState);
 		presenter.onAttach(this);
+	}
+
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		presenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override
@@ -34,21 +39,58 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 
 	@Override
 	public void navigateToUpload() {
-		backStackName = UploadQRFragment.class.getSimpleName();
+		final String fragmentName = UploadQRFragment.class.getSimpleName();
 		UploadQRFragment fragment = (UploadQRFragment) getSupportFragmentManager()
-			.findFragmentByTag(backStackName);
+			.findFragmentByTag(fragmentName);
 
 		if (fragment == null) {
 			fragment = UploadQRFragment.newInstance();
+			replaceFragment(fragment, fragmentName, fragmentName, false);
+		} else {
+			// We should not add to back stack because it's already in stack.
+			replaceFragment(fragment, null, fragmentName, false);
 		}
-		replaceFragment(fragment, backStackName, false);
 	}
 
-	private void replaceFragment(Fragment fragment, String fragmentName, boolean addAnimation) {
+	@Override
+	public void navigateToEnterPassword(String keystoreData) {
+		final String fragmentName = RestoreEnterPasswordFragment.class.getSimpleName();
+		RestoreEnterPasswordFragment fragment = (RestoreEnterPasswordFragment) getSupportFragmentManager()
+			.findFragmentByTag(fragmentName);
+
+		if (fragment == null) {
+			fragment = RestoreEnterPasswordFragment.newInstance(keystoreData, this);
+			replaceFragment(fragment, fragmentName, fragmentName, true);
+		} else {
+			fragment.setKeyboardHandler(this);
+			// We should not add to back stack because it's already in stack.
+			replaceFragment(fragment, null, fragmentName, true);
+		}
+	}
+
+	@Override
+	public void navigateToRestoreCompleted(Integer accountIndex) {
+		final String fragmentName = RestoreCompletedFragment.class.getSimpleName();
+		RestoreCompletedFragment fragment = (RestoreCompletedFragment) getSupportFragmentManager()
+			.findFragmentByTag(fragmentName);
+
+		if (fragment == null) {
+			fragment = RestoreCompletedFragment.newInstance(accountIndex);
+			replaceFragment(fragment, fragmentName, fragmentName, true);
+		} else {
+			// We should not add to back stack because it's already in stack.
+			replaceFragment(fragment, null, fragmentName, true);
+		}
+	}
+
+	private void replaceFragment(Fragment fragment, String backStackName, String tag, boolean addAnimation) {
 		FragmentTransaction transaction = getSupportFragmentManager()
 			.beginTransaction()
-			.replace(R.id.fragment_frame, fragment)
-			.addToBackStack(fragmentName);
+			.replace(R.id.fragment_frame, fragment, tag);
+
+		if (backStackName != null) {
+			transaction.addToBackStack(backStackName);
+		}
 
 		if (addAnimation) {
 			transaction.setCustomAnimations(
@@ -61,34 +103,22 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 	}
 
 	@Override
-	public void navigateToEnterPassword(String keystoreData) {
-		backStackName = RestoreEnterPasswordFragment.class.getSimpleName();
-		RestoreEnterPasswordFragment fragment = (RestoreEnterPasswordFragment) getSupportFragmentManager()
-			.findFragmentByTag(backStackName);
-
-		if (fragment == null) {
-			fragment = RestoreEnterPasswordFragment.newInstance(keystoreData, this);
-		}
-
-		replaceFragment(fragment, backStackName, true);
-	}
-
-	@Override
-	public void navigateToRestoreCompleted(Integer accountIndex) {
-		backStackName = RestoreCompletedFragment.class.getSimpleName();
-		RestoreCompletedFragment fragment = (RestoreCompletedFragment) getSupportFragmentManager()
-			.findFragmentByTag(backStackName);
-
-		if (fragment == null) {
-			fragment = RestoreCompletedFragment.newInstance(accountIndex);
-		}
-
-		replaceFragment(fragment, backStackName, true);
-	}
-
-	@Override
 	public void navigateBack() {
+		int count = getSupportFragmentManager().getBackStackEntryCount();
+		if (count == 3) {
+			// After pressing back from RestoreCompletedPage, should put the attrs again.
+			// This is the only fragment that should set arguments again on back.
+			RestoreEnterPasswordFragment enterPasswordFragment = getSavedRestoreEnterPasswordFragment();
+			if (enterPasswordFragment != null) {
+				enterPasswordFragment.setKeyboardHandler(this);
+			}
+		}
 		getSupportFragmentManager().popBackStack(null, 0);
+	}
+
+	private RestoreEnterPasswordFragment getSavedRestoreEnterPasswordFragment() {
+		return (RestoreEnterPasswordFragment) getSupportFragmentManager()
+			.findFragmentByTag(RestoreEnterPasswordFragment.class.getSimpleName());
 	}
 
 	@Override
@@ -96,6 +126,11 @@ public class RestoreActivity extends BaseToolbarActivity implements RestoreView 
 		closeKeyboard(); // Verify the keyboard is hidden
 		finish();
 		overridePendingTransition(0, R.anim.kinrecovery_slide_out_right);
+	}
+
+	@Override
+	public void showError() {
+		Toast.makeText(this, R.string.kinrecovery_something_went_wrong_title, Toast.LENGTH_SHORT).show();
 	}
 
 	public RestorePresenter getPresenter() {

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreCompletedFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreCompletedFragment.java
@@ -1,6 +1,8 @@
 package com.kin.ecosystem.recovery.restore.view;
 
 
+import static com.kin.ecosystem.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_INDEX;
+
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -16,14 +18,13 @@ import com.kin.ecosystem.recovery.restore.presenter.RestoreCompletedPresenterImp
 
 public class RestoreCompletedFragment extends Fragment implements RestoreCompletedView {
 
-	private static final String BUNDLE_KEY_ACCOUNT_ID = "BUNDLE_KEY_ACCOUNT_ID";
 	private RestoreCompletedPresenter presenter;
 
 	public static RestoreCompletedFragment newInstance(Integer accountIndex) {
 		RestoreCompletedFragment fragment = new RestoreCompletedFragment();
 		if (accountIndex != -1) {
 			Bundle bundle = new Bundle();
-			bundle.putInt(BUNDLE_KEY_ACCOUNT_ID, accountIndex);
+			bundle.putInt(KEY_ACCOUNT_INDEX, accountIndex);
 			fragment.setArguments(bundle);
 		}
 		return fragment;
@@ -35,8 +36,8 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 		@Nullable Bundle savedInstanceState) {
 		View root = inflater.inflate(R.layout.kinrecovery_fragment_restore_completed, container, false);
 
-		int accountId = extractAccountId(savedInstanceState);
-		injectPresenter(accountId);
+		int accountIndex = extractAccountIndex(savedInstanceState);
+		injectPresenter(accountIndex);
 		presenter.onAttach(this, ((RestoreActivity) getActivity()).getPresenter());
 
 		initToolbar();
@@ -44,20 +45,26 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 		return root;
 	}
 
-	private int extractAccountId(@Nullable Bundle savedInstanceState) {
-		Bundle bundle = savedInstanceState != null ? savedInstanceState : getArguments();
-		if (bundle == null) {
-			throw new IllegalStateException("Bundle is null, can't extract required accountId data.");
-		}
-		int accountId = bundle.getInt(BUNDLE_KEY_ACCOUNT_ID, -1);
-		if (accountId == -1) {
-			throw new IllegalStateException("Can't find accountId data inside Bundle.");
-		}
-		return accountId;
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		presenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
 	}
 
-	private void injectPresenter(int accountId) {
-		presenter = new RestoreCompletedPresenterImpl(accountId);
+	private int extractAccountIndex(@Nullable Bundle savedInstanceState) {
+		Bundle bundle = savedInstanceState != null ? savedInstanceState : getArguments();
+		if (bundle == null) {
+			throw new IllegalStateException("Bundle is null, can't extract required accountIndex data.");
+		}
+		int accountIndex = bundle.getInt(KEY_ACCOUNT_INDEX, -1);
+		if (accountIndex == -1) {
+			throw new IllegalStateException("Can't find accountIndex data inside Bundle.");
+		}
+		return accountIndex;
+	}
+
+	private void injectPresenter(int accountIndex) {
+		presenter = new RestoreCompletedPresenterImpl(accountIndex);
 	}
 
 	private void initToolbar() {
@@ -77,7 +84,7 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 		root.findViewById(R.id.kinrecovery_v_btn).setOnClickListener(new OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				presenter.finish();
+				presenter.close();
 			}
 		});
 	}

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
@@ -68,12 +68,6 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 	}
 
 	@Override
-	public void onStop() {
-		super.onStop();
-		keyboardHandler.closeKeyboard();
-	}
-
-	@Override
 	public void onSaveInstanceState(Bundle outState) {
 		presenter.onSaveInstanceState(outState);
 		super.onSaveInstanceState(outState);

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreEnterPasswordFragment.java
@@ -1,6 +1,8 @@
 package com.kin.ecosystem.recovery.restore.view;
 
 
+import static com.kin.ecosystem.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_KEY;
+
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -28,8 +30,8 @@ import com.kin.ecosystem.recovery.widget.PasswordEditText;
 
 public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnterPasswordView {
 
-	private static final String BUNDLE_KEY_KEYSTORE = "BUNDLE_KEY_KEYSTORE";
 	public static final int VIEW_MIN_DELAY_MILLIS = 50;
+
 	private RestoreEnterPasswordPresenter presenter;
 	private KeyboardHandler keyboardHandler;
 	private Button doneBtn;
@@ -42,13 +44,13 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 		fragment.setKeyboardHandler(keyboardHandler);
 		if (keystoreData != null) {
 			Bundle bundle = new Bundle();
-			bundle.putString(BUNDLE_KEY_KEYSTORE, keystoreData);
+			bundle.putString(KEY_ACCOUNT_KEY, keystoreData);
 			fragment.setArguments(bundle);
 		}
 		return fragment;
 	}
 
-	private void setKeyboardHandler(@NonNull KeyboardHandler keyboardHandler) {
+	public void setKeyboardHandler(@NonNull KeyboardHandler keyboardHandler) {
 		this.keyboardHandler = keyboardHandler;
 	}
 
@@ -65,6 +67,18 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 		return root;
 	}
 
+	@Override
+	public void onStop() {
+		super.onStop();
+		keyboardHandler.closeKeyboard();
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		presenter.onSaveInstanceState(outState);
+		super.onSaveInstanceState(outState);
+	}
+
 	@NonNull
 	private String extractKeyStoreData(@Nullable Bundle savedInstanceState) {
 		String keystoreData;
@@ -72,7 +86,7 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 		if (bundle == null) {
 			throw new IllegalStateException("Bundle is null, can't extract required keystore data.");
 		}
-		keystoreData = bundle.getString(BUNDLE_KEY_KEYSTORE);
+		keystoreData = bundle.getString(KEY_ACCOUNT_KEY);
 		if (keystoreData == null) {
 			throw new IllegalStateException("Can't find keystore data inside Bundle.");
 		}

--- a/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreView.java
+++ b/recovery/src/main/java/com/kin/ecosystem/recovery/restore/view/RestoreView.java
@@ -16,4 +16,6 @@ public interface RestoreView extends BaseView {
 	void close();
 
 	void closeKeyboard();
+
+	void showError();
 }


### PR DESCRIPTION
#### Main purpose:
The crash appeared while having the developer option of don't keep activities.
This fix is only for restore flow, back flow is done.
#### Technical description:
Add save instance state mechanism for the fragments and main activity `RestoreActivity`
