### PR TITLE
fix crash of orderhistory don't keep activities

### DIFF
--- a/app/src/main/java/com/ecosystem/kin/app/App.java
+++ b/app/src/main/java/com/ecosystem/kin/app/App.java
@@ -22,7 +22,7 @@ public class App extends Application {
 
         Fabric.with(this, new Crashlytics());
 
-		KinEnvironment environment = Environment.getPlayground();
+		KinEnvironment environment = Environment.getBeta();
 
         if (BuildConfig.IS_JWT_REGISTRATION) {
             /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.58
+SAMPLE_VERSION_NAME=0.0.60
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.3
 

--- a/sdk/src/main/java/com/kin/ecosystem/main/presenter/EcosystemPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/main/presenter/EcosystemPresenter.java
@@ -7,6 +7,7 @@ import static com.kin.ecosystem.main.ScreenId.ORDER_HISTORY;
 import static com.kin.ecosystem.main.Title.MARKETPLACE_TITLE;
 import static com.kin.ecosystem.main.Title.ORDER_HISTORY_TITLE;
 
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import com.kin.ecosystem.base.BasePresenter;
 import com.kin.ecosystem.common.Observer;
@@ -21,6 +22,7 @@ import java.math.BigDecimal;
 
 public class EcosystemPresenter extends BasePresenter<IEcosystemView> implements IEcosystemPresenter {
 
+	public static final String KEY_SCREEN_ID = "screen_id";
 	private @ScreenId
 	int visibleScreen = NONE;
 	private final INavigator navigator;
@@ -32,27 +34,51 @@ public class EcosystemPresenter extends BasePresenter<IEcosystemView> implements
 
 	public EcosystemPresenter(@NonNull IEcosystemView view, @NonNull SettingsDataSource settingsDataSource,
 		@NonNull final BlockchainSource blockchainSource,
-		@NonNull INavigator navigator) {
+		@NonNull INavigator navigator, Bundle savedInstanceState) {
 		this.view = view;
 		this.settingsDataSource = settingsDataSource;
 		this.blockchainSource = blockchainSource;
 		this.navigator = navigator;
 		this.currentBalance = blockchainSource.getBalance();
+		this.visibleScreen = getVisibleScreen(savedInstanceState);
 
 		this.view.attachPresenter(this);
+	}
+
+	private int getVisibleScreen(Bundle savedInstanceState) {
+		return savedInstanceState != null ? savedInstanceState.getInt(KEY_SCREEN_ID, NONE) : NONE;
 	}
 
 	@Override
 	public void onAttach(IEcosystemView view) {
 		super.onAttach(view);
-		if (this.view != null && visibleScreen != MARKETPLACE) {
-			navigator.navigateToMarketplace();
+		navigateToVisibleScreen(visibleScreen);
+	}
+
+	private void navigateToVisibleScreen(int visibleScreen) {
+		if (view != null) {
+			switch (visibleScreen) {
+				case ORDER_HISTORY:
+					navigator.navigateToOrderHistory(false);
+					break;
+				case MARKETPLACE:
+				case NONE:
+				default:
+					navigator.navigateToMarketplace();
+					break;
+
+			}
 		}
 	}
 
 	@Override
 	public void onStart() {
 		updateMenuSettingsIcon();
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle outState) {
+		outState.putInt(KEY_SCREEN_ID, visibleScreen);
 	}
 
 	@Override

--- a/sdk/src/main/java/com/kin/ecosystem/main/presenter/IEcosystemPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/main/presenter/IEcosystemPresenter.java
@@ -1,5 +1,6 @@
 package com.kin.ecosystem.main.presenter;
 
+import android.os.Bundle;
 import com.kin.ecosystem.base.IBasePresenter;
 import com.kin.ecosystem.main.ScreenId;
 import com.kin.ecosystem.main.view.IEcosystemView;
@@ -17,4 +18,6 @@ public interface IEcosystemPresenter extends IBasePresenter<IEcosystemView> {
 	void onMenuInitialized();
 
 	void onStart();
+
+	void onSaveInstanceState(Bundle outState);
 }

--- a/sdk/src/main/java/com/kin/ecosystem/main/view/EcosystemActivity.java
+++ b/sdk/src/main/java/com/kin/ecosystem/main/view/EcosystemActivity.java
@@ -268,7 +268,7 @@ public class EcosystemActivity extends BaseToolbarActivity implements IEcosystem
 			overridePendingTransition(0, R.anim.kinecosystem_slide_out_right);
 		} else {
 			BackStackEntry entry = getSupportFragmentManager().getBackStackEntryAt(count - 1);
-			if (entry.getName().equals(MARKETPLACE_TO_ORDER_HISTORY)) {
+			if (entry != null && entry.getName().equals(MARKETPLACE_TO_ORDER_HISTORY)) {
 				// After pressing back from OrderHistory, should put the attrs again.
 				// This is the only fragment that should set presenter again on back.
 				MarketplaceFragment marketplaceFragment = getSavedMarketplaceFragment();

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
@@ -3,6 +3,7 @@ package com.kin.ecosystem.marketplace.view;
 import android.support.annotation.IntDef;
 import com.kin.ecosystem.base.IBaseView;
 import com.kin.ecosystem.core.network.model.Offer;
+import com.kin.ecosystem.marketplace.presenter.IMarketplacePresenter;
 import com.kin.ecosystem.marketplace.presenter.ISpendDialogPresenter;
 import com.kin.ecosystem.marketplace.presenter.MarketplacePresenter;
 import com.kin.ecosystem.poll.view.PollWebViewActivity.PollBundle;
@@ -10,7 +11,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 
-public interface IMarketplaceView extends IBaseView<MarketplacePresenter> {
+public interface IMarketplaceView extends IBaseView<IMarketplacePresenter> {
 
 	int NOT_ENOUGH_KIN = 0x00000001;
 	int SOMETHING_WENT_WRONG = 0x00000002;

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceFragment.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceFragment.java
@@ -60,7 +60,7 @@ public class MarketplaceFragment extends Fragment implements IMarketplaceView {
 	}
 
 	@Override
-	public void attachPresenter(MarketplacePresenter presenter) {
+	public void attachPresenter(IMarketplacePresenter presenter) {
 		marketplacePresenter = presenter;
 	}
 


### PR DESCRIPTION
#### Main purpose:
Crash after activity restart due to `don't keep activities` (low memory devices)
#### Technical description:
Save screen id on saveInstanceState and use it on restart activity
