### PR TITLE
remove getOffers call from init

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.60
+SAMPLE_VERSION_NAME=0.0.61
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.4
 

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -14,6 +14,7 @@ import com.kin.ecosystem.common.ObservableData;
 import com.kin.ecosystem.common.Observer;
 import com.kin.ecosystem.common.exception.BlockchainException;
 import com.kin.ecosystem.common.exception.ClientException;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.common.model.Balance;
 import com.kin.ecosystem.common.model.NativeOffer;
 import com.kin.ecosystem.common.model.OrderConfirmation;
@@ -21,6 +22,7 @@ import com.kin.ecosystem.common.model.UserStats;
 import com.kin.ecosystem.common.model.WhitelistData;
 import com.kin.ecosystem.core.Configuration;
 import com.kin.ecosystem.core.Logger;
+import com.kin.ecosystem.core.accountmanager.AccountManager;
 import com.kin.ecosystem.core.accountmanager.AccountManagerImpl;
 import com.kin.ecosystem.core.accountmanager.AccountManagerLocal;
 import com.kin.ecosystem.core.bi.EventLogger;
@@ -37,6 +39,7 @@ import com.kin.ecosystem.core.data.offer.OfferRepository;
 import com.kin.ecosystem.core.data.order.OrderLocalData;
 import com.kin.ecosystem.core.data.order.OrderRemoteData;
 import com.kin.ecosystem.core.data.order.OrderRepository;
+import com.kin.ecosystem.core.network.model.AuthToken;
 import com.kin.ecosystem.core.network.model.SignInData;
 import com.kin.ecosystem.core.network.model.SignInData.SignInTypeEnum;
 import com.kin.ecosystem.core.network.model.UserProfile;
@@ -176,7 +179,6 @@ public class Kin {
 
 	private static void initOfferRepository() {
 		OfferRepository.init(OfferRemoteData.getInstance(instance.executorsUtil), OrderRepository.getInstance());
-		OfferRepository.getInstance().getOffers(null);
 	}
 
 	private static void initOrderRepository(@NonNull final Context context) {

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -89,16 +89,20 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 				OfferListUtil.splitOffersByType(cachedOfferList.getOffers(), this.earnList, this.spendList);
 			}
 		}
-		setOfferLists();
+		setCachedOfferLists();
 	}
 
-	private void setOfferLists() {
+	private void setCachedOfferLists() {
 		if (this.view != null) {
 			this.view.setEarnList(earnList);
 			this.view.setSpendList(spendList);
 
-			setEarnEmptyViewState();
-			setSpendEmptyViewState();
+			if (!earnList.isEmpty()) {
+				updateEarnTitle();
+			}
+			if (!spendList.isEmpty()) {
+				updateSpendTitle();
+			}
 		}
 	}
 
@@ -128,7 +132,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 				if (offer.getId().equals(offerId)) {
 					earnList.remove(i);
 					notifyEarnItemRemoved(i);
-					setEarnEmptyViewState();
+					updateEarnTitle();
 					return;
 				}
 			}
@@ -138,21 +142,21 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 				if (offer.getId().equals(offerId)) {
 					spendList.remove(i);
 					notifySpendItemRemoved(i);
-					setSpendEmptyViewState();
+					updateSpendTitle();
 					return;
 				}
 			}
 		}
 	}
 
-	private void setEarnEmptyViewState() {
+	private void updateEarnTitle() {
 		boolean isEarnListEmpty = earnList.isEmpty();
 		if (view != null) {
 			view.updateEarnSubtitle(isEarnListEmpty);
 		}
 	}
 
-	private void setSpendEmptyViewState() {
+	private void updateSpendTitle() {
 		boolean isSpendListEmpty = spendList.isEmpty();
 		if (view != null) {
 			view.updateSpendSubtitle(isSpendListEmpty);
@@ -198,9 +202,16 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 		this.offerRepository.getOffers(new KinCallbackAdapter<OfferList>() {
 			@Override
 			public void onResponse(OfferList offerList) {
+				setupEmptyItemView();
 				syncOffers(offerList);
 			}
 		});
+	}
+
+	private void setupEmptyItemView() {
+		if (view != null) {
+			view.setupEmptyItemView();
+		}
 	}
 
 	private void syncOffers(OfferList offerList) {
@@ -242,9 +253,9 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 		}
 
 		if (offerType == OfferType.EARN) {
-			setEarnEmptyViewState();
+			updateEarnTitle();
 		} else {
-			setSpendEmptyViewState();
+			updateSpendTitle();
 		}
 	}
 
@@ -259,10 +270,10 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 	private void notifyItemInserted(int index, OfferType offerType) {
 		if (isSpend(offerType)) {
 			notifySpendItemInserted(index);
-			setSpendEmptyViewState();
+			updateSpendTitle();
 		} else {
 			notifyEarnItemInserted(index);
-			setEarnEmptyViewState();
+			updateEarnTitle();
 		}
 	}
 
@@ -272,8 +283,9 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	@Override
 	public void onItemClicked(int position, OfferType offerType) {
-		if (position == NOT_FOUND)
+		if (position == NOT_FOUND) {
 			return;
+		}
 
 		final Offer offer;
 		if (offerType == OfferType.EARN) {

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -9,9 +9,11 @@ import android.support.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.kin.ecosystem.base.BasePresenter;
+import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.KinCallbackAdapter;
 import com.kin.ecosystem.common.NativeOfferClickEvent;
 import com.kin.ecosystem.common.Observer;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.common.model.NativeOffer;
 import com.kin.ecosystem.core.bi.EventLogger;
 import com.kin.ecosystem.core.bi.events.BackButtonOnMarketplacePageTapped;
@@ -199,11 +201,18 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 
 	@Override
 	public void getOffers() {
-		this.offerRepository.getOffers(new KinCallbackAdapter<OfferList>() {
+		this.offerRepository.getOffers(new KinCallback<OfferList>() {
 			@Override
 			public void onResponse(OfferList offerList) {
 				setupEmptyItemView();
 				syncOffers(offerList);
+			}
+
+			@Override
+			public void onFailure(KinEcosystemException exception) {
+				setupEmptyItemView();
+				updateEarnTitle();
+				updateSpendTitle();
 			}
 		});
 	}

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/view/IMarketplaceView.java
@@ -16,6 +16,7 @@ public interface IMarketplaceView extends IBaseView<IMarketplacePresenter> {
 	int NOT_ENOUGH_KIN = 0x00000001;
 	int SOMETHING_WENT_WRONG = 0x00000002;
 
+
 	@IntDef({NOT_ENOUGH_KIN, SOMETHING_WENT_WRONG})
 	@Retention(RetentionPolicy.SOURCE)
 	@interface Message {
@@ -25,6 +26,8 @@ public interface IMarketplaceView extends IBaseView<IMarketplacePresenter> {
 	void setSpendList(List<Offer> response);
 
 	void setEarnList(List<Offer> response);
+
+	void setupEmptyItemView();
 
 	void showOfferActivity(PollBundle pollBundle);
 

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceFragment.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/view/MarketplaceFragment.java
@@ -85,7 +85,6 @@ public class MarketplaceFragment extends Fragment implements IMarketplaceView {
 				marketplacePresenter.onItemClicked(position, OfferType.SPEND);
 			}
 		});
-		spendRecyclerAdapter.setEmptyView(new OffersEmptyView(getContext()));
 
 		//Earn Recycler
 		RecyclerView earnRecycler = root.findViewById(R.id.earn_recycler);
@@ -99,7 +98,6 @@ public class MarketplaceFragment extends Fragment implements IMarketplaceView {
 				marketplacePresenter.onItemClicked(position, OfferType.EARN);
 			}
 		});
-		earnRecyclerAdapter.setEmptyView(new OffersEmptyView(getContext()));
 
 	}
 
@@ -112,6 +110,12 @@ public class MarketplaceFragment extends Fragment implements IMarketplaceView {
 	@Override
 	public void setEarnList(List<Offer> earnList) {
 		earnRecyclerAdapter.setNewData(earnList);
+	}
+
+	@Override
+	public void setupEmptyItemView() {
+		spendRecyclerAdapter.setEmptyView(new OffersEmptyView(getContext()));
+		earnRecyclerAdapter.setEmptyView(new OffersEmptyView(getContext()));
 	}
 
 	@Override


### PR DESCRIPTION
#### Main purpose:
It was causing to duplication of requests for AuthToken, and stress on the server while it got failed and had retry.
#### Technical description:
- Remove the call for `getOffers` and only call it on the marketplace activity.
- Handle empty offers view on the first start, added the empty view only after the request callback for offers.

