### PR TITLE
make sure list not null before sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.64
+SAMPLE_VERSION_NAME=0.0.65
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.6
 

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -203,9 +203,9 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 	}
 
 	private void release() {
+		orderRepository.removeOrderObserver(orderObserver);
 		earnList = null;
 		spendList = null;
-		orderRepository.removeOrderObserver(orderObserver);
 	}
 
 	@Override
@@ -244,6 +244,9 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 	}
 
 	private void syncList(List<Offer> newList, List<Offer> oldList, OfferType offerType) {
+		// Make sure olsList is not null
+		if (oldList == null) { oldList = new ArrayList<>(); }
+
 		// check if offer should be removed (index changed / removed from list).
 		if (newList.size() > 0) {
 			for (int i = 0; i < oldList.size(); i++) {

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -238,7 +238,7 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 			List<Offer> newSpendOffers = new ArrayList<>();
 
 			OfferListUtil.splitOffersByType(offerList.getOffers(), newEarnOffers, newSpendOffers);
-			g
+			
 			if (earnList == null) { earnList = new ArrayList<>(); }
 			if (spendList == null) { spendList = new ArrayList<>(); }
 			syncList(newEarnOffers, earnList, OfferType.EARN);

--- a/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/marketplace/presenter/MarketplacePresenter.java
@@ -238,15 +238,15 @@ public class MarketplacePresenter extends BasePresenter<IMarketplaceView> implem
 			List<Offer> newSpendOffers = new ArrayList<>();
 
 			OfferListUtil.splitOffersByType(offerList.getOffers(), newEarnOffers, newSpendOffers);
+			g
+			if (earnList == null) { earnList = new ArrayList<>(); }
+			if (spendList == null) { spendList = new ArrayList<>(); }
 			syncList(newEarnOffers, earnList, OfferType.EARN);
 			syncList(newSpendOffers, spendList, OfferType.SPEND);
 		}
 	}
 
 	private void syncList(List<Offer> newList, List<Offer> oldList, OfferType offerType) {
-		// Make sure olsList is not null
-		if (oldList == null) { oldList = new ArrayList<>(); }
-
 		// check if offer should be removed (index changed / removed from list).
 		if (newList.size() > 0) {
 			for (int i = 0; i < oldList.size(); i++) {


### PR DESCRIPTION
#### Main purpose:
old list was null, on an edge case of receiving Offers from the server and going to order history so the presenter being detached.
#### Technical description:
- make sure old list is not null by creating new ArrayList if it's null
- removing the order observer before assigning the `earnList` and `spendList` to null `onDetach`.

