### PR TITLE
Eco/load account after process restart

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.71
+SAMPLE_VERSION_NAME=0.0.72
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.9
 

--- a/sdk/src/main/java/com/kin/ecosystem/base/KinEcosystemInitiator.java
+++ b/sdk/src/main/java/com/kin/ecosystem/base/KinEcosystemInitiator.java
@@ -2,9 +2,11 @@ package com.kin.ecosystem.base;
 
 import android.content.Context;
 import com.kin.ecosystem.Kin;
+import com.kin.ecosystem.common.exception.BlockchainException;
 import com.kin.ecosystem.common.exception.ClientException;
 import com.kin.ecosystem.core.Log;
 import com.kin.ecosystem.core.Logger;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSourceImpl;
 
 final class KinEcosystemInitiator {
 
@@ -16,7 +18,9 @@ final class KinEcosystemInitiator {
 	protected static void init(Context context) {
 		try {
 			Kin.initialize(context);
-		} catch (ClientException e) {
+			// If we had process restart we should load the account.
+			BlockchainSourceImpl.getInstance().createAccount();
+		} catch (ClientException | BlockchainException e) {
 			Logger.log(new Log().withTag(TAG).text("KinEcosystem sdk auto initialize failed"));
 		}
 	}


### PR DESCRIPTION
#### Main purpose:
The account is not loaded on init so we should call createAccount that will load that last account after process restart.
