### PR TITLE
Eco 891/restore doesnt switch account

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManagerImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManagerImpl.java
@@ -186,15 +186,12 @@ public class AccountManagerImpl implements AccountManager {
 		authRepository.updateWalletAddress(address, new KinCallback<Boolean>() {
 			@Override
 			public void onResponse(Boolean response) {
-				try {
-					//switch to the new KinAccount
-					blockchainSource.updateActiveAccount(accountIndex);
-				} catch (BlockchainException e) {
-					callback.onFailure(ErrorUtil.getBlockchainException(e));
-					return;
+				//switch to the new KinAccount
+				if(blockchainSource.updateActiveAccount(accountIndex)) {
+					callback.onResponse(response);
+				} else {
+					callback.onFailure(ErrorUtil.createAccountCannotLoadedException(accountIndex));
 				}
-				Logger.log(new Log().withTag(TAG).put("switchAccount", "ended successfully"));
-				callback.onResponse(response);
 			}
 
 			@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -99,7 +99,12 @@ public interface BlockchainSource {
 	 */
 	KeyStoreProvider getKeyStoreProvider();
 
-	void updateActiveAccount(int accountIndex);
+	/**
+	 * Update the activated account
+	 * @param accountIndex the new account to load
+	 * @return true if switch was succeed
+	 */
+	boolean updateActiveAccount(int accountIndex);
 
 	interface Local {
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -99,7 +99,7 @@ public interface BlockchainSource {
 	 */
 	KeyStoreProvider getKeyStoreProvider();
 
-	void updateActiveAccount(int accountIndex) throws BlockchainException;
+	void updateActiveAccount(int accountIndex);
 
 	interface Local {
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -394,10 +394,10 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	@Override
-	public void updateActiveAccount(int accountIndex) throws BlockchainException {
-		if (activeAccountIndex != accountIndex && accountIndex != -1) {
+	public void updateActiveAccount(int accountIndex) {
+		if (activeAccountIndex != accountIndex && accountIndex != -1 && accountIndex < kinClient.getAccountCount()) {
 			setAccountIndex(accountIndex);
-			createKinAccountIfNeeded();
+			account = kinClient.getAccount(activeAccountIndex);
 			reconnectBalanceConnection();
 			//trigger balance update
 			getBalance(null);

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -394,14 +394,16 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	@Override
-	public void updateActiveAccount(int accountIndex) {
+	public boolean updateActiveAccount(int accountIndex) {
 		if (activeAccountIndex != accountIndex && accountIndex != -1 && accountIndex < kinClient.getAccountCount()) {
 			setAccountIndex(accountIndex);
 			account = kinClient.getAccount(activeAccountIndex);
 			reconnectBalanceConnection();
 			//trigger balance update
 			getBalance(null);
+			return true;
 		}
+		return false;
 	}
 
 	private void setAccountIndex(int accountIndex) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-SAMPLE_VERSION_NAME=0.0.72
+g
+SAMPLE_VERSION_NAME=0.0.73
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.9
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-g
+
 SAMPLE_VERSION_NAME=0.0.73
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.2.9


### PR DESCRIPTION
#### Main purpose:
Update account after restore didn't work as expected, didn't switch the account only after force close.
#### Technical description:
- load account directly from kinClient and not calling createAccountIfNeeded.

