### PR TITLE
Eco 898/polling server for get order on sse timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.0.75
+SAMPLE_VERSION_NAME=0.0.76
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=0.3.0
 


### PR DESCRIPTION
#### Main purpose:
Client didn't get callback for native order completed due to timeout with the SSE connection to the blockchain.
#### Technical description:
- add timeout task for the SSE connection, if after 15sec the client didn't notified about the transaction,
start getOrder polling to the server. 

