### PR TITLE
Enable Auto Backup and include required shared preference files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ For Beta: ("beta")
 ```
 And for Production use: `@string/kinecosystem_environment_production` as value. 
 
+## Enable Auto backup ##
+Android Auto Backup automatically backs up apps data that target and run on Android 6.0 (API level 23) and above.
+Enabling auto backup will provide better experience when user uninstall and reinstall the app.
+No extra action is needed, if auto backup is enabled and ```android:fullBackupContent``` is not defined.
+Otherwise the app module AndroidManifest.xml should include these attributes.
+```xml
+ <application
+        android:allowBackup="true"
+        tools:replace="android:allowBackup"
+        android:fullBackupContent="@xml/backup_rules">  
+</application>
+```
+and ```backup_rules.xml``` should include 
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" path="KinKeyStore_kinecosystem_store.xml"/>
+</full-backup-content>
+```
+Auto backup is not 100% guaranteed and may not work for all users.
+To learn more on Auto Backup features and constraints see [Android Auto Backup](https://developer.android.com/guide/topics/data/autobackup) 
+
 
 >**NOTES:**
 >* When working with the Beta environment, you can only register up to 1000 users. An attempt to register additional users will result in an error.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,8 +6,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="false"
+        android:allowBackup="true"
         tools:replace="android:allowBackup"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/java/com/ecosystem/kin/app/MainActivity.java
+++ b/app/src/main/java/com/ecosystem/kin/app/MainActivity.java
@@ -19,6 +19,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.TextView;
 import android.widget.Toast;
+import com.ecosystem.kin.app.model.AutoBackupRepo;
 import com.ecosystem.kin.app.model.SignInRepo;
 import com.kin.ecosystem.EcosystemExperience;
 import com.kin.ecosystem.Kin;
@@ -177,6 +178,15 @@ public class MainActivity extends AppCompatActivity {
 		});
 		((TextView) findViewById(R.id.sample_app_version))
 			.setText(getString(R.string.version_name, BuildConfig.VERSION_NAME));
+
+		final TextView backupSessionsTextView = findViewById(R.id.backup_session);
+		final int numberOfBackupSessions = AutoBackupRepo.getNumberOfBackupedSessions(getApplicationContext());
+		backupSessionsTextView.setText(getString(R.string.backup_sessions, numberOfBackupSessions));
+
+		final TextView sessionsTextView = findViewById(R.id.sessions);
+		final int numberOfSessions = AutoBackupRepo.getNumberOfSessions(getApplicationContext());
+		sessionsTextView.setText(getString(R.string.sessions, numberOfSessions));
+		AutoBackupRepo.incrementNumberOfSessions(getApplicationContext());
 	}
 
 

--- a/app/src/main/java/com/ecosystem/kin/app/model/AutoBackupRepo.java
+++ b/app/src/main/java/com/ecosystem/kin/app/model/AutoBackupRepo.java
@@ -1,0 +1,50 @@
+package com.ecosystem.kin.app.model;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class AutoBackupRepo {
+
+	private final static String AUTO_BACKUP_PREFERENCE_FILE_KEY = "auto_backup_file";
+	private final static String NO_BACKUP_PREFERENCE_FILE_KEY = "no_backup_file";
+	private final static String NUMBER_OF_SESSIONS_KEY = "NUMBER_OF_SESSIONS_KEY";
+
+
+	private static SharedPreferences getAutoBackupSharedPreferences(Context context) {
+		return context
+			.getSharedPreferences(AUTO_BACKUP_PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
+	}
+
+	private static SharedPreferences getNoBackupSharedPreferences(Context context) {
+		return context
+			.getSharedPreferences(NO_BACKUP_PREFERENCE_FILE_KEY, Context.MODE_PRIVATE);
+	}
+
+	@NonNull
+	public static int getNumberOfBackupedSessions(Context context) {
+		return getNumberOfSessions(getAutoBackupSharedPreferences(context));
+	}
+
+	@NonNull
+	public static int getNumberOfSessions(Context context) {
+		return getNumberOfSessions(getNoBackupSharedPreferences(context));
+	}
+
+	private static int getNumberOfSessions(SharedPreferences sharedPreferences) {
+		return sharedPreferences.getInt(NUMBER_OF_SESSIONS_KEY, 0);
+	}
+
+
+	public static void incrementNumberOfSessions(Context context) {
+		incrementNumberOfSessions(getNoBackupSharedPreferences(context));
+		incrementNumberOfSessions(getAutoBackupSharedPreferences(context));
+	}
+
+	private static void incrementNumberOfSessions(SharedPreferences sharedPreferences) {
+		int numberOfSessions = sharedPreferences.getInt(NUMBER_OF_SESSIONS_KEY, 0) + 1;
+		sharedPreferences.edit().putInt(NUMBER_OF_SESSIONS_KEY, numberOfSessions).apply();
+	}
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,38 @@
     android:background="@color/colorPrimary"
     tools:context="com.ecosystem.kin.app.MainActivity">
 
+
+    <TextView
+        android:id="@+id/backup_session"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/kinecosystem_main_margin"
+        android:layout_marginLeft="@dimen/kinecosystem_margin_large"
+        android:layout_gravity="bottom"
+        android:gravity="center_horizontal"
+        android:text="Backup sessions:"
+        android:textAllCaps="false"
+        android:textColor="@color/kinecosystem_white"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf= "parent"
+        />
+
+    <TextView
+        android:id="@+id/sessions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/kinecosystem_main_margin"
+        android:layout_marginRight="@dimen/kinecosystem_margin_large"
+        android:layout_gravity="bottom"
+        android:gravity="center_horizontal"
+        android:text="Sessions:"
+        android:textAllCaps="false"
+        android:textColor="@color/kinecosystem_white"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        />
+
+
     <ImageView
         android:id="@+id/logo"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,10 @@
     <string name="get_user_stats">Get User Stats</string>
     <string name="version_name">Version: %s</string>
     <string name="user_id">User ID: %s</string>
+    <string name="backup_sessions">Backup sessions: %d</string>
+    <string name="sessions">Sessions: %d</string>
+
+
     <string name="enter_the_recipient_user_id">Enter the recipient user id:</string>
     <string name="pay">Pay</string>
     <string name="native_offer_content_activity">Native Offer Content Activity</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <include domain="sharedpref" path="KinKeyStore_kinecosystem_store.xml"/>
+    <include domain="sharedpref" path="auto_backup_file.xml"/>
+</full-backup-content>


### PR DESCRIPTION
#### Main purpose:
Enable auto backup in sample app to test and provide guidelines to DS 
#### Technical description:
Enable auto backup and set files that need to be included - all other files will be excluded
#### Dilemmas you faced with? 
Apps that disabled auto backup might not want to auto-backup all data - using include files solve this issue.
Also, this is not a full proof solution and it doesn't guarantee that wallet will be auto backup
#### Tests:
tested with https://developer.android.com/guide/topics/data/testingbackup and check that only included files were included in the backup.
#### Documentation:
Updated README.md