### PR TITLE
Send login succeed after on-boarding

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     api devDependencies.kinCore
     implementation devDependencies.okhttp3
     implementation devDependencies.loginInterceptor3
+    implementation devDependencies.kotlin
 
     testImplementation project(':test-base')
     testImplementation testingDependencies.mockitoKotlin

--- a/core/src/main/java/com/kin/ecosystem/core/CoreCallback.kt
+++ b/core/src/main/java/com/kin/ecosystem/core/CoreCallback.kt
@@ -1,0 +1,9 @@
+package com.kin.ecosystem.core
+
+import java.lang.Exception
+
+interface CoreCallback<T> {
+    fun onResponse(response: T?)
+
+    fun onFailure(exception: Exception)
+}

--- a/core/src/main/java/com/kin/ecosystem/core/PollingRequest.kt
+++ b/core/src/main/java/com/kin/ecosystem/core/PollingRequest.kt
@@ -1,0 +1,41 @@
+package com.kin.ecosystem.core
+
+import java.util.concurrent.Callable
+
+internal class PollingRequest<T>(private val intervals: IntArray, private val callable: Callable<T>) {
+
+    companion object {
+        const val SECOND_IN_MILLIS: Long = 1000
+    }
+
+    private val pollingLimitIndex: Int = intervals.size
+    private var request: Request<T>? = null
+    private val pollingCallable = Callable<T> {
+        Logger.log(Log().withTag("PollingRequest").text("start polling"))
+        poll(0)
+    }
+
+
+    private fun poll(pollingIndex: Int): T {
+        return try {
+            Logger.log(Log().withTag("PollingRequest").put("pollingIndex", pollingIndex))
+            callable.call()
+        } catch (e: Exception) {
+            if (pollingIndex < pollingLimitIndex) {
+                Thread.sleep(intervals[pollingIndex] * SECOND_IN_MILLIS)
+                poll(pollingIndex.inc())
+            } else {
+                throw e
+            }
+        }
+    }
+
+    fun run(callback: CoreCallback<T>) {
+        request = Request(pollingCallable)
+        request?.run(callback)
+    }
+
+    fun cancel(mayInterruptIfRunning: Boolean) {
+        request?.cancel(mayInterruptIfRunning)
+    }
+}

--- a/core/src/main/java/com/kin/ecosystem/core/Request.kt
+++ b/core/src/main/java/com/kin/ecosystem/core/Request.kt
@@ -1,0 +1,96 @@
+package com.kin.ecosystem.core
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+/**
+ * Each request will run sequentially on background thread,
+ * and will notify [CoreCallback] onResponse or onFailure on main thread.
+ *
+ * @param <T> request result type
+</T> */
+internal open class Request<T> internal constructor(private val callable: Callable<T>) {
+    private val mainHandler: Handler
+    private var cancelled: Boolean = false
+    private var executed: Boolean = false
+    private var future: Future<*>? = null
+    private var resultCallback: CoreCallback<T>? = null
+
+    init {
+        checkNotNull(callable, "callable")
+        this.mainHandler = Handler(Looper.getMainLooper())
+    }
+
+    /**
+     * Run request asynchronously, notify `callback` with successful result or error
+     */
+    @Synchronized
+    fun run(callback: CoreCallback<T>) {
+        checkBeforeRun(callback)
+        executed = true
+        submitFuture(callable, callback)
+    }
+
+    private fun checkBeforeRun(callback: CoreCallback<T>) {
+        checkNotNull(callback, "callback")
+        if (executed) {
+            throw IllegalStateException("Request already running.")
+        }
+        if (cancelled) {
+            throw IllegalStateException("Request already cancelled.")
+        }
+    }
+
+    private fun checkNotNull(param: Any?, name: String) {
+        if (param == null) {
+            throw IllegalArgumentException("$name cannot be null.")
+        }
+    }
+
+    private fun submitFuture(callable: Callable<T>, callback: CoreCallback<T>) {
+        this.resultCallback = callback
+        future = executorService.submit {
+            try {
+                val result = callable.call()
+                executeOnMainThreadIfNotCancelled(Runnable { resultCallback!!.onResponse(result) })
+            } catch (e: Exception) {
+                executeOnMainThreadIfNotCancelled(Runnable { resultCallback!!.onFailure(e) })
+            }
+        }
+    }
+
+    @Synchronized
+    private fun executeOnMainThreadIfNotCancelled(runnable: Runnable) {
+        if (!cancelled) {
+            mainHandler.post(runnable)
+        }
+    }
+
+    /**
+     * Cancel `Request` and detach its callback,
+     * an attempt will be made to cancel ongoing request, if request has not run yet it will never run.
+     *
+     * @param mayInterruptIfRunning true if the request should be interrupted; otherwise, in-progress requests are
+     * allowed to complete
+     */
+    @Synchronized
+    fun cancel(mayInterruptIfRunning: Boolean) {
+        if (!cancelled) {
+            cancelled = true
+            if (future != null) {
+                future!!.cancel(mayInterruptIfRunning)
+            }
+            future = null
+            mainHandler.removeCallbacksAndMessages(null)
+            mainHandler.post { resultCallback = null }
+        }
+    }
+
+    companion object {
+
+        private val executorService = Executors.newSingleThreadExecutor()
+    }
+}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/AccountCreationRequest.kt
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/AccountCreationRequest.kt
@@ -12,13 +12,17 @@ import java.util.concurrent.Callable
 
 class AccountCreationRequest(val blockchainSource: BlockchainSource) {
 
-    private var req: PollingRequest<Void>? = null
+    private var req: PollingRequest<Void>
 
-    fun start(callback: KinCallback<Void>) {
+    init {
         req = PollingRequest(intervals = intArrayOf(2, 2, 3, 5, 10), callable = Callable<Void> {
             blockchainSource.balanceSync
-            return@Callable null })
-        req?.run(object : CoreCallback<Void> {
+            return@Callable null
+        })
+    }
+
+    fun run(callback: KinCallback<Void>) {
+        req.run(object : CoreCallback<Void> {
             override fun onResponse(response: Void?) {
                 callback.onResponse(response)
             }
@@ -34,7 +38,7 @@ class AccountCreationRequest(val blockchainSource: BlockchainSource) {
     }
 
     fun cancel() {
-        req?.cancel(true)
+        req.cancel(true)
     }
 }
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/AccountCreationRequest.kt
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/AccountCreationRequest.kt
@@ -1,0 +1,41 @@
+package com.kin.ecosystem.core.data.blockchain
+
+import com.kin.ecosystem.common.KinCallback
+import com.kin.ecosystem.common.exception.BlockchainException
+import com.kin.ecosystem.common.exception.ClientException
+import com.kin.ecosystem.common.exception.ClientException.INTERNAL_INCONSISTENCY
+import com.kin.ecosystem.common.exception.KinEcosystemException
+import com.kin.ecosystem.core.CoreCallback
+import com.kin.ecosystem.core.PollingRequest
+import com.kin.ecosystem.core.util.ErrorUtil
+import java.util.concurrent.Callable
+
+class AccountCreationRequest(val blockchainSource: BlockchainSource) {
+
+    private var req: PollingRequest<Void>? = null
+
+    fun start(callback: KinCallback<Void>) {
+        req = PollingRequest(intervals = intArrayOf(2, 2, 3, 5, 10), callable = Callable<Void> {
+            blockchainSource.balanceSync
+            return@Callable null })
+        req?.run(object : CoreCallback<Void> {
+            override fun onResponse(response: Void?) {
+                callback.onResponse(response)
+            }
+
+            override fun onFailure(exception: Exception) {
+                if (exception is ClientException || exception is BlockchainException) {
+                    callback.onFailure(exception as KinEcosystemException)
+                } else {
+                    callback.onFailure(ErrorUtil.getClientException(INTERNAL_INCONSISTENCY, exception))
+                }
+            }
+        })
+    }
+
+    fun cancel() {
+        req?.cancel(true)
+    }
+}
+
+

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -29,6 +29,12 @@ public interface BlockchainSource {
 	KinAccount getKinAccount();
 
 	/**
+	 * Start a polling call to account's balance to check if account was created.
+	 * @param callback - onResponse if account was created, otherwise onFailure will be triggered.
+	 */
+	void isAccountCreated(KinCallback<Void> callback);
+
+	/**
 	 * Send transaction to the network
 	 *
 	 * @param publicAddress the recipient address
@@ -47,6 +53,11 @@ public interface BlockchainSource {
 	 * Get balance from network
 	 */
 	void getBalance(@Nullable final KinCallback<Balance> callback);
+
+	/**
+	 * Get balance from network
+	 */
+	Balance getBalanceSync() throws ClientException, BlockchainException;
 
 	/**
 	 * Reconnect the balance connection, due to connection lose.

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -64,6 +64,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	private int paymentObserversCount;
 	private int balanceObserversCount;
 
+	private AccountCreationRequest accountCreationRequest;
 	private ListenerRegistration paymentRegistration;
 	private ListenerRegistration balanceRegistration;
 
@@ -188,6 +189,16 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	@Override
+	public void isAccountCreated(KinCallback<Void> callback) {
+		if(accountCreationRequest != null) {
+			accountCreationRequest.cancel();
+		}
+
+		accountCreationRequest = new AccountCreationRequest(this);
+		accountCreationRequest.start(callback);
+	}
+
+	@Override
 	public void sendTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
 		@NonNull final String orderID, @NonNull final String offerID) {
 		if (account != null) {
@@ -280,6 +291,19 @@ public class BlockchainSourceImpl implements BlockchainSource {
 				Logger.log(new Log().withTag(TAG).priority(Log.ERROR).put("getBalance onError", e));
 			}
 		});
+	}
+
+	@Override
+	public Balance getBalanceSync() throws ClientException, BlockchainException {
+		if (account == null) {
+			throw ErrorUtil.getClientException(ClientException.ACCOUNT_NOT_LOGGED_IN, null);
+		}
+		try {
+			setBalance(account.getBalanceSync());
+			return balance.getValue();
+		} catch (OperationFailedException e) {
+			throw ErrorUtil.getBlockchainException(e);
+		}
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -195,7 +195,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		}
 
 		accountCreationRequest = new AccountCreationRequest(this);
-		accountCreationRequest.start(callback);
+		accountCreationRequest.run(callback);
 	}
 
 	@Override

--- a/core/src/test/kotlin/com/kin/ecosystem/core/accountmanager/AccountManagerImplTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/accountmanager/AccountManagerImplTest.kt
@@ -115,10 +115,11 @@ class AccountManagerImplTest : BaseTestClass() {
 
         accountManager.addAccountStateObserver(stateObserver)
         accountManager.start()
-        argumentCaptor<EventListener<Void>>().apply {
-            verify(blockchainEvents).addAccountCreationListener(capture())
-            firstValue.onEvent(null)
+        argumentCaptor<KinCallback<Void>>().apply {
+            verify(blockchainSource).isAccountCreated(capture())
+            firstValue.onResponse(null)
         }
+
 
         assertEquals(listOf(1, 1, 2, 4), stateList)
     }
@@ -151,9 +152,9 @@ class AccountManagerImplTest : BaseTestClass() {
         whenever(local.accountState).doReturn(REQUIRE_CREATION)
         accountManager.addAccountStateObserver(stateObserver)
         accountManager.retry()
-        argumentCaptor<EventListener<Void>>().apply {
-            verify(blockchainEvents).addAccountCreationListener(capture())
-            firstValue.onEvent(null)
+        argumentCaptor<KinCallback<Void>>().apply {
+            verify(blockchainSource).isAccountCreated(capture())
+            firstValue.onResponse(null)
         }
 
         assertEquals(listOf(5, 1, 2, 4).toList(), statesArray)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,7 @@ ext {
     gsonVersion = '2.8.2'
     hamcrestVersion = '1.3'
     zxingVersion = '3.3.3'
+    kotlinVersion = kotlin_version
 
     //Packages
     kinFoundationPackage = 'com.github.kinfoundation'
@@ -18,12 +19,12 @@ ext {
     okhttp3Packace = 'com.squareup.okhttp3'
     gsonPackage = 'com.google.code.gson'
     zxingPackage = 'com.google.zxing'
+    kotlinPackage = 'org.jetbrains.kotlin'
 
     //Testing Version
     junitVersion = '4.12'
     mockitoVersion = '2.13.0'
     robolectricVersion = '3.6.1'
-    kotlinVersion = kotlin_version
     mokitoKotlinVersion = '2.0.0-RC1'
     mockitoAndroidVersion = '2.10.0'
     androidTestVersion = '1.0.1'
@@ -32,7 +33,6 @@ ext {
     junitPackage = 'junit'
     mockitoPackage = 'org.mockito'
     robolectricPackage = 'org.robolectric'
-    kotlinPackage = 'org.jetbrains.kotlin'
     mokitoKotlinPackage = 'com.nhaarman.mockitokotlin2'
     androidTestPackage = 'com.android.support.test'
     hamcrestPackage = 'org.hamcrest'
@@ -49,13 +49,13 @@ ext {
             loginInterceptor3 : buildDependency(okhttp3Packace, 'logging-interceptor', okhttp3Version),
             supportAnnotations: buildDependency(supportPackage, 'support-annotations', supportVersion),
             zxing_qr: buildDependency(zxingPackage, 'core', zxingVersion),
+            kotlin      : buildDependency(kotlinPackage, 'kotlin-stdlib', kotlinVersion),
     ]
 
     testingDependencies = [
             junit       : buildDependency(junitPackage, 'junit', junitVersion),
             mockito     : buildDependency(mockitoPackage, 'mockito-core', mockitoVersion),
             robolectric : buildDependency(robolectricPackage, 'robolectric', robolectricVersion),
-            kotlin      : buildDependency(kotlinPackage, 'kotlin-stdlib', kotlinVersion),
             mockitoKotlin: buildDependency(mokitoKotlinPackage, 'mockito-kotlin', mokitoKotlinVersion),
             mockitoAndroid   : buildDependency(mockitoPackage, 'mockito-android', mockitoAndroidVersion),
             androidTestRunner: buildDependency(androidTestPackage, 'runner', androidTestVersion),

--- a/recovery/build.gradle
+++ b/recovery/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     androidTestImplementation testingDependencies.androidTestRunner
     androidTestImplementation testingDependencies.hamcrest
 
-    testImplementation testingDependencies.kotlin
+    testImplementation devDependencies.kotlin
     testImplementation testingDependencies.mockitoKotlin
     testImplementation testingDependencies.junit
     testImplementation testingDependencies.mockito

--- a/test-base/build.gradle
+++ b/test-base/build.gradle
@@ -16,7 +16,7 @@ android {
 
 dependencies {
     implementation project(':core')
-    api testingDependencies.kotlin
+    api devDependencies.kotlin
     api testingDependencies.junit
 
 }


### PR DESCRIPTION
#### Main purpose:
The developer now can use any of the SDK API's after login succeed response
#### Technical description:
- create a polling request for account balance and make sure he is ready.
- listen for account state on the login process
- added Kotlin
- update `AccountManagerImplTest`
