### PR TITLE
fix crash for orientation on translucent style activity

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/util/DeviceUtils.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/DeviceUtils.java
@@ -2,6 +2,7 @@ package com.kin.ecosystem.core.util;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.support.annotation.IntDef;
 import android.util.DisplayMetrics;
 
@@ -71,6 +72,10 @@ public class DeviceUtils {
 
     public static int getScreenWidth() {
         return screenWidth;
+    }
+
+    public static boolean isBelowAndroidVersion(int androidVersion) {
+        return Build.VERSION.SDK_INT < androidVersion;
     }
 
 }

--- a/core/src/main/java/com/kin/ecosystem/core/util/DeviceUtils.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/DeviceUtils.java
@@ -2,7 +2,6 @@ package com.kin.ecosystem.core.util;
 
 import android.content.Context;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.support.annotation.IntDef;
 import android.util.DisplayMetrics;
 
@@ -73,9 +72,4 @@ public class DeviceUtils {
     public static int getScreenWidth() {
         return screenWidth;
     }
-
-    public static boolean isBelowAndroidVersion(int androidVersion) {
-        return Build.VERSION.SDK_INT < androidVersion;
-    }
-
 }

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -30,8 +30,9 @@
 
         <activity
             android:name=".transfer.view.AccountInfoActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
-            android:theme="@style/KinecosysNoActionBar.Transparent" />
+            android:theme="@style/KinecosysNoActionBar" />
 
     </application>
 

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
 
         <activity
             android:name=".transfer.view.AccountInfoActivity"
-            android:screenOrientation="portrait"
             android:exported="true"
             android:theme="@style/KinecosysNoActionBar.Transparent" />
 

--- a/sdk/src/main/java/com/kin/ecosystem/transfer/view/AccountInfoActivity.java
+++ b/sdk/src/main/java/com/kin/ecosystem/transfer/view/AccountInfoActivity.java
@@ -1,12 +1,14 @@
 package com.kin.ecosystem.transfer.view;
 
+import android.content.pm.ActivityInfo;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.TextView;
-
 import com.kin.ecosystem.R;
 import com.kin.ecosystem.base.KinEcosystemBaseActivity;
+import com.kin.ecosystem.core.util.DeviceUtils;
 import com.kin.ecosystem.transfer.AccountInfoManager;
 import com.kin.ecosystem.transfer.presenter.AccountInfoPresenter;
 import com.kin.ecosystem.transfer.presenter.IAccountInfoPresenter;
@@ -17,6 +19,10 @@ public class AccountInfoActivity extends KinEcosystemBaseActivity implements IAc
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        //On android above Oreo, you can not change orientation for Activity that has android:windowIsTranslucent=true
+        if (DeviceUtils.isBelowAndroidVersion(Build.VERSION_CODES.O)) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        }
         presenter = new AccountInfoPresenter(new AccountInfoManager(this), this, getIntent());
     }
 

--- a/sdk/src/main/java/com/kin/ecosystem/transfer/view/AccountInfoActivity.java
+++ b/sdk/src/main/java/com/kin/ecosystem/transfer/view/AccountInfoActivity.java
@@ -1,14 +1,11 @@
 package com.kin.ecosystem.transfer.view;
 
-import android.content.pm.ActivityInfo;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.TextView;
 import com.kin.ecosystem.R;
 import com.kin.ecosystem.base.KinEcosystemBaseActivity;
-import com.kin.ecosystem.core.util.DeviceUtils;
 import com.kin.ecosystem.transfer.AccountInfoManager;
 import com.kin.ecosystem.transfer.presenter.AccountInfoPresenter;
 import com.kin.ecosystem.transfer.presenter.IAccountInfoPresenter;
@@ -19,10 +16,6 @@ public class AccountInfoActivity extends KinEcosystemBaseActivity implements IAc
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //On android above Oreo, you can not change orientation for Activity that has android:windowIsTranslucent=true
-        if (DeviceUtils.isBelowAndroidVersion(Build.VERSION_CODES.O)) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        }
         presenter = new AccountInfoPresenter(new AccountInfoManager(this), this, getIntent());
     }
 

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -69,9 +69,4 @@
         <item name="android:windowExitAnimation">@anim/kinecosystem_slide_down</item>
     </style>
 
-    <style name="KinecosysNoActionBar.Transparent" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name = "android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowIsTranslucent">true</item>
-    </style>
-
 </resources>


### PR DESCRIPTION
#### Main purpose:
On android above Oreo, you can not change orientation for Activity that has `android:windowIsTranslucent=true` style item.

https://stackoverflow.com/a/51131880/2775465