### PR TITLE
migration login flow and how to post orders

### DIFF
--- a/common/src/main/java/com/kin/ecosystem/common/exception/BlockchainException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/BlockchainException.java
@@ -8,7 +8,7 @@ public class BlockchainException extends KinEcosystemException {
 
 	@IntDef({ACCOUNT_CREATION_FAILED, ACCOUNT_NOT_FOUND,
 		ACCOUNT_ACTIVATION_FAILED, INSUFFICIENT_KIN,
-		TRANSACTION_FAILED, ACCOUNT_LOADING_FAILED, UNKNOWN})
+		TRANSACTION_FAILED, ACCOUNT_LOADING_FAILED, MIGRATION_FAILED, UNKNOWN})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface BlockchainErrorCodes {
 
@@ -20,6 +20,7 @@ public class BlockchainException extends KinEcosystemException {
 	public static final int INSUFFICIENT_KIN = 6004;
 	public static final int TRANSACTION_FAILED = 6005;
 	public static final int ACCOUNT_LOADING_FAILED = 6006;
+	public static final int MIGRATION_FAILED = 6007;
 
 	public BlockchainException(@BlockchainErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/common/src/main/java/com/kin/ecosystem/common/exception/ClientException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/ClientException.java
@@ -17,6 +17,7 @@ public class ClientException extends KinEcosystemException {
 	public static final int BAD_CONFIGURATION = 4002;
 	public static final int INTERNAL_INCONSISTENCY = 4003;
 	public static final int ACCOUNT_NOT_LOGGED_IN = 4004;
+	public static final int BLOCKCHAIN_ENDPOINT_CHANGED = 4101;
 
 	public ClientException(@ClientErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/common/src/main/java/com/kin/ecosystem/common/exception/ClientException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/ClientException.java
@@ -17,7 +17,6 @@ public class ClientException extends KinEcosystemException {
 	public static final int BAD_CONFIGURATION = 4002;
 	public static final int INTERNAL_INCONSISTENCY = 4003;
 	public static final int ACCOUNT_NOT_LOGGED_IN = 4004;
-	public static final int BLOCKCHAIN_ENDPOINT_CHANGED = 4101;
 
 	public ClientException(@ClientErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/common/src/main/java/com/kin/ecosystem/common/exception/ServiceException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/ServiceException.java
@@ -7,7 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 
 public class ServiceException extends KinEcosystemException {
 
-	@IntDef({SERVICE_ERROR, NETWORK_ERROR, TIMEOUT_ERROR, USER_NOT_FOUND, ORDER_FAILED, USER_HAS_NO_WALLET, BLOCKCHAIN_ENDPOINT_CHANGED})
+	@IntDef({SERVICE_ERROR, NETWORK_ERROR, TIMEOUT_ERROR, USER_NOT_FOUND, ORDER_FAILED, USER_HAS_NO_WALLET,
+		BLOCKCHAIN_ENDPOINT_CHANGED, WALLET_WAS_NOT_CREATED_IN_THIS_APP})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface ServiceErrorCodes {
 
@@ -20,6 +21,7 @@ public class ServiceException extends KinEcosystemException {
 	public static final int ORDER_FAILED = 5005;
 	public static final int USER_HAS_NO_WALLET = 5006;
 	public static final int BLOCKCHAIN_ENDPOINT_CHANGED = 5007;
+	public static final int WALLET_WAS_NOT_CREATED_IN_THIS_APP = 5008;
 
 	public ServiceException(@ServiceErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/common/src/main/java/com/kin/ecosystem/common/exception/ServiceException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/ServiceException.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 
 public class ServiceException extends KinEcosystemException {
 
-	@IntDef({SERVICE_ERROR, NETWORK_ERROR, TIMEOUT_ERROR, USER_NOT_FOUND, ORDER_FAILED, USER_HAS_NO_WALLET})
+	@IntDef({SERVICE_ERROR, NETWORK_ERROR, TIMEOUT_ERROR, USER_NOT_FOUND, ORDER_FAILED, USER_HAS_NO_WALLET, BLOCKCHAIN_ENDPOINT_CHANGED})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface ServiceErrorCodes {
 
@@ -19,6 +19,7 @@ public class ServiceException extends KinEcosystemException {
 	public static final int USER_NOT_FOUND = 5004;
 	public static final int ORDER_FAILED = 5005;
 	public static final int USER_HAS_NO_WALLET = 5006;
+	public static final int BLOCKCHAIN_ENDPOINT_CHANGED = 5007;
 
 	public ServiceException(@ServiceErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -14,10 +14,18 @@ import com.kin.ecosystem.recovery.KeyStoreProvider;
 import java.math.BigDecimal;
 import kin.sdk.migration.MigrationManager;
 import kin.sdk.migration.common.KinSdkVersion;
+import kin.sdk.migration.common.exception.DeleteAccountException;
 import kin.sdk.migration.common.exception.OperationFailedException;
 import kin.sdk.migration.common.interfaces.IKinAccount;
 
 public interface BlockchainSource {
+
+	/**
+	 * Get the migration info from the server.
+	 * @param publicAddress the address associated with the migration information.
+	 * @param callback a callback for this method call.
+	 */
+	void getMigrationInfo(String publicAddress, Callback<MigrationInfo, ApiException> callback);
 
 	/**
 	 * Set the migration manager
@@ -37,10 +45,19 @@ public interface BlockchainSource {
 
 	/**
 	 * Starts the migration process using the migration module for a specific public address
-	 * @param listener
 	 * @param publicAddress
+	 * @param listener
 	 */
-	void startMigrationProcess(final MigrationProcessListener listener, final String publicAddress);
+	void startMigrationProcess(final String publicAddress, final MigrationProcessListener listener);
+
+	/**
+	 * Starts the migration process using the migration module for a specific public address and with a migration info object.
+	 * @param migrationInfo is the migration information needed to continue with the migration process, if null
+	 * then this method will get if from the server.
+	 * @param publicAddress is the address of the account to migrate.
+	 * @param listener is the migration process listener needed in order to get callbacks regarding the migration process
+	 */
+	void startMigrationProcess(MigrationInfo migrationInfo, final String publicAddress, final MigrationProcessListener listener);
 
 	/**
 	 * Create account if there is no accounts in local
@@ -161,6 +178,8 @@ public interface BlockchainSource {
 	void logout();
 
 	KinSdkVersion getBlockchainVersion();
+
+	void deleteAccount(int accountIndex) throws DeleteAccountException;
 
 	interface Local {
 		int getBalance();

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -13,6 +13,7 @@ import com.kin.ecosystem.recovery.KeyStoreProvider;
 import java.math.BigDecimal;
 import kin.sdk.migration.MigrationManager;
 import kin.sdk.migration.common.KinSdkVersion;
+import kin.sdk.migration.common.exception.OperationFailedException;
 import kin.sdk.migration.common.interfaces.IKinAccount;
 
 public interface BlockchainSource {
@@ -55,7 +56,7 @@ public interface BlockchainSource {
 	 * @param listener to be informed when a transaction is signed and ready
 	 */
 	void signTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount, @NonNull String orderID,
-		@NonNull String offerID, @NonNull SignTransactionListener listener);
+		@NonNull String offerID, @NonNull SignTransactionListener listener) throws OperationFailedException;
 
 	/**
 	 * Send transaction to the network

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -162,6 +162,8 @@ public interface BlockchainSource {
 
 	KinSdkVersion getBlockchainVersion();
 
+	void fetchBlockchainVersion(Callback<KinSdkVersion, ApiException> callback);
+
 	interface Local {
 		int getBalance();
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -25,6 +25,24 @@ public interface BlockchainSource {
 	void setMigrationManager(@NonNull final MigrationManager migrationManager);
 
 	/**
+	 * Starts the migration process using the migration module
+	 */
+	void startMigrationProcess();
+
+	/**
+	 * Starts the migration process using the migration module
+	 * @param listener
+	 */
+	void startMigrationProcess(final MigrationProcessListener listener);
+
+	/**
+	 * Starts the migration process using the migration module for a specific public address
+	 * @param listener
+	 * @param publicAddress
+	 */
+	void startMigrationProcess(final MigrationProcessListener listener, final String publicAddress);
+
+	/**
 	 * Create account if there is no accounts in local
 	 * @param kinUserId the logged in account
 	 * @throws BlockchainException could not load the account, or could not create a new account.

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -179,7 +179,7 @@ public interface BlockchainSource {
 
 	KinSdkVersion getBlockchainVersion();
 
-	void fetchBlockchainVersion(Callback<KinSdkVersion, ApiException> callback);
+	void fetchBlockchainVersion(KinCallback<KinSdkVersion> callback);
 
 	void deleteAccount(int accountIndex) throws DeleteAccountException;
 
@@ -221,7 +221,9 @@ public interface BlockchainSource {
 
 	interface MigrationProcessListener {
 		void onMigrationStart();
+
 		void onMigrationEnd();
+
 		void onMigrationError(BlockchainException error);
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -9,6 +9,7 @@ import com.kin.ecosystem.common.exception.BlockchainException;
 import com.kin.ecosystem.common.exception.ClientException;
 import com.kin.ecosystem.common.model.Balance;
 import com.kin.ecosystem.core.network.ApiException;
+import com.kin.ecosystem.core.network.model.MigrationInfo;
 import com.kin.ecosystem.recovery.KeyStoreProvider;
 import java.math.BigDecimal;
 import kin.sdk.migration.MigrationManager;
@@ -170,7 +171,13 @@ public interface BlockchainSource {
 
 	interface Remote {
 		KinSdkVersion getBlockchainVersion() throws ApiException; // synced and blocking
+
 		void getBlockchainVersion(@NonNull final Callback<KinSdkVersion, ApiException> callback);
+
+		MigrationInfo getMigrationInfo(String publicAddress)  throws ApiException; // synced and blocking
+
+		void getMigrationInfo(String publicAddress, @NonNull final Callback<MigrationInfo, ApiException> callback);
+
 	}
 
 	interface MigrationProcessListener {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -171,6 +171,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 			remote.getBlockchainVersion(new Callback<KinSdkVersion, ApiException>() {
 				@Override
 				public void onResponse(KinSdkVersion sdkVersion) {
+					local.setBlockchainVersion(sdkVersion);
 					updateKinClient(migrationManager.getKinClient(sdkVersion));
 					listener.onMigrationEnd();
 				}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -119,6 +119,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	private void updateKinClient(IKinClient kinClient) {
+		Logger.log(new Log().withTag("MOO").text(kinClient.getEnvironment().getNetworkUrl()));
 		this.kinClient = kinClient;
 	}
 
@@ -243,13 +244,15 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 	@Override
 	public void signTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
-		@NonNull final String orderID, @NonNull final String offerID, @NonNull final SignTransactionListener listener) {
+		@NonNull final String orderID, @NonNull final String offerID, @NonNull final SignTransactionListener listener) throws OperationFailedException {
+		Logger.log(new Log().withTag("MOO").text("signTransaction 1"));
 		if (account != null) {
+			Logger.log(new Log().withTag("MOO").text("signTransaction 2"));
 			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
-			account.sendTransaction(publicAddress, amount, new IWhitelistService() {
+			account.sendTransactionSync(publicAddress, amount, new IWhitelistService() {
 				@Override
-				public WhitelistResult onWhitelistableTransactionReady(IWhitelistableTransaction transaction)
-					throws WhitelistTransactionFailedException {
+				public WhitelistResult onWhitelistableTransactionReady(IWhitelistableTransaction transaction) {
+					Logger.log(new Log().withTag("MOO").text("signTransaction 3"));
 					listener.onTransactionSigned(transaction.getTransactionPayload());
 					return new WhitelistResult(transaction.getTransactionPayload(), false);
 				}
@@ -260,6 +263,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	@Override
 	public void sendTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
 		@NonNull final String orderID, @NonNull final String offerID) {
+		Logger.log(new Log().withTag("MOO").text("sendTransaction 1"));
 		if (account != null) {
 			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
 			account.sendTransaction(publicAddress, amount, new IWhitelistService() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -35,6 +35,7 @@ import kin.sdk.migration.MigrationManager;
 import kin.sdk.migration.common.KinSdkVersion;
 import kin.sdk.migration.common.WhitelistResult;
 import kin.sdk.migration.common.exception.CreateAccountException;
+import kin.sdk.migration.common.exception.DeleteAccountException;
 import kin.sdk.migration.common.exception.MigrationInProcessException;
 import kin.sdk.migration.common.exception.OperationFailedException;
 import kin.sdk.migration.common.exception.WhitelistTransactionFailedException;
@@ -139,66 +140,94 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	@Override
-	public void startMigrationProcess(final MigrationProcessListener listener) {
+	public void startMigrationProcess(MigrationProcessListener listener) {
 		try {
-			startMigrationProcess(listener, getPublicAddress());
+			startMigrationProcess(null, getPublicAddress(), listener);
 		} catch (BlockchainException e) {
-			// TODO: handle this
+			// TODO: handle this, maybe just do listener.onMigrationError(e); or do something else because of that exception
 		}
 	}
 
 	@Override
-	public void startMigrationProcess(final MigrationProcessListener listener, final String publicAddress) {
+	public void startMigrationProcess(String publicAddress, MigrationProcessListener listener) {
+		startMigrationProcess(null, publicAddress, listener);
+	}
+
+	@Override
+	public void startMigrationProcess(MigrationInfo migrationInfo, final String publicAddress, final MigrationProcessListener listener) {
 		// Check if we have an account, if yes then get the migration info and check if this account should migrate.
 		// If the account should migrate then migrate it, if not update the kinClient to run on this version.
 		// If we don't have an account then check the server for the current version and update the kinClient to run on this version.
 		if (kinClient.hasAccount()) {
-			// final String publicAddress = kinClient.getAccount(0).getPublicAddress();
-			// TODO: 01/04/2019 Maybe we can make it more efficient by adding a call to the local storage to check if the account is already migrated(localy)?
-			remote.getMigrationInfo(publicAddress,
-					new Callback<MigrationInfo, ApiException>() {
-						@Override
-						public void onResponse(MigrationInfo migrationInfo) {
-							KinSdkVersion kinSdkVersion = KinSdkVersion.get(migrationInfo.getBlockchainVersion());
-							local.setBlockchainVersion(kinSdkVersion); // In any case update the version locally.
-							if (migrationInfo.shouldMigrate()) {
-								startMigration(publicAddress, listener);
-							} else {
-								updateKinClient(migrationManager.getKinClient(kinSdkVersion));
-								if (listener != null) {
-									listener.onMigrationEnd();
-								}
-							}
-						}
-
-						@Override
-						public void onFailure(ApiException exception) {
-							// TODO: 31/03/2019 handle error like in any other place in the app, find what kind of error...
-							// TODO: 01/04/2019 and if got account not found, which probably means that the account is only created locally then handle it.
-							if (listener != null) {
-								listener.onMigrationError(new BlockchainException(BlockchainException.MIGRATION_FAILED, "Migration Failed", exception));
-								listener.onMigrationEnd();
-							}
-						}
-					});
+			// final String publicAddress = kinClient.getAccount(0).getPublicAddress(); todo remove comment when finish with testings
+			// TODO: 01/04/2019 Maybe we can make it more efficient by adding a call to the local storage to check if the account is already migrated(locally)?
+			if (migrationInfo != null) {
+				startMigrationIfNeeded(migrationInfo, publicAddress, listener);
+			} else {
+				handleMigrationInfo(publicAddress, listener);
+			}
 		} else {
 			remote.getBlockchainVersion(new Callback<KinSdkVersion, ApiException>() {
 				@Override
 				public void onResponse(KinSdkVersion sdkVersion) {
-					local.setBlockchainVersion(sdkVersion);
+					setBlockchainVersion(sdkVersion);
 					updateKinClient(migrationManager.getKinClient(sdkVersion));
 					listener.onMigrationEnd();
 				}
 
 				@Override
 				public void onFailure(ApiException exception) {
-					// TODO: 31/03/2019 handle error like in any other place in the app, find what kind of error...
 					if (listener != null) {
 						listener.onMigrationError(new BlockchainException(BlockchainException.MIGRATION_FAILED, "Migration Failed", exception));
+
+						// TODO: 02/04/2019 not sure that it is ok for you to call onError and then onEnd which means success, it should only be one of them
 						listener.onMigrationEnd();
 					}
 				}
 			});
+		}
+	}
+
+	private void handleMigrationInfo(final String publicAddress, final MigrationProcessListener listener) {
+		getMigrationInfo(publicAddress,
+			new Callback<MigrationInfo, ApiException>() {
+				@Override
+				public void onResponse(MigrationInfo migrationInfo) {
+					startMigrationIfNeeded(migrationInfo, publicAddress, listener);
+				}
+
+				@Override
+				public void onFailure(ApiException exception) {
+					// TODO: 01/04/2019 if got account not found exception, which probably means that the account is only created locally then maybe handle it somehow.
+
+					if (listener != null) {
+						listener.onMigrationError(
+							new BlockchainException(BlockchainException.MIGRATION_FAILED, "Migration Failed",
+								exception));
+						// TODO: 02/04/2019 not sure that it is ok for you to call onError and then onEnd which means success, it should only be one of them
+						listener.onMigrationEnd();
+					}
+				}
+			});
+	}
+
+	@Override
+	public void getMigrationInfo(String publicAddress, Callback<MigrationInfo, ApiException> callback) {
+		remote.getMigrationInfo(publicAddress, callback);
+	}
+
+	private void startMigrationIfNeeded(MigrationInfo migrationInfo, String publicAddress,
+		MigrationProcessListener listener) {
+		// In any case update the version locally.
+		KinSdkVersion sdkVersion = KinSdkVersion.get(migrationInfo.getBlockchainVersion());
+		setBlockchainVersion(sdkVersion);
+		if (migrationInfo.shouldMigrate()) {
+			startMigration(publicAddress, listener);
+		} else  {
+			updateKinClient(migrationManager.getKinClient(KinSdkVersion.get(migrationInfo.getBlockchainVersion())));
+			if (listener != null) {
+				listener.onMigrationEnd();
+			}
 		}
 	}
 
@@ -230,6 +259,10 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		} catch (MigrationInProcessException e) {
 			e.printStackTrace();
 		}
+	}
+
+	private void setBlockchainVersion(KinSdkVersion sdkVersion) {
+		local.setBlockchainVersion(sdkVersion);
 	}
 
 	@Override
@@ -375,6 +408,13 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
 		return local.getBlockchainVersion();
+	}
+
+	@Override
+	public void deleteAccount(int accountIndex) throws DeleteAccountException {
+		if (local.getAccountIndex() < accountIndex) {
+			kinClient.deleteAccount(accountIndex);
+		}
 	}
 
 	private void initBalance() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -119,7 +119,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	private void updateKinClient(IKinClient kinClient) {
-		Logger.log(new Log().withTag("MOO").text(kinClient.getEnvironment().getNetworkUrl()));
 		this.kinClient = kinClient;
 	}
 
@@ -245,14 +244,11 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	@Override
 	public void signTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
 		@NonNull final String orderID, @NonNull final String offerID, @NonNull final SignTransactionListener listener) throws OperationFailedException {
-		Logger.log(new Log().withTag("MOO").text("signTransaction 1"));
 		if (account != null) {
-			Logger.log(new Log().withTag("MOO").text("signTransaction 2"));
 			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
 			account.sendTransactionSync(publicAddress, amount, new IWhitelistService() {
 				@Override
 				public WhitelistResult onWhitelistableTransactionReady(IWhitelistableTransaction transaction) {
-					Logger.log(new Log().withTag("MOO").text("signTransaction 3"));
 					listener.onTransactionSigned(transaction.getTransactionPayload());
 					return new WhitelistResult(transaction.getTransactionPayload(), false);
 				}
@@ -263,7 +259,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	@Override
 	public void sendTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
 		@NonNull final String orderID, @NonNull final String offerID) {
-		Logger.log(new Log().withTag("MOO").text("sendTransaction 1"));
 		if (account != null) {
 			eventLogger.send(SpendTransactionBroadcastToBlockchainSubmitted.create(offerID, orderID));
 			account.sendTransaction(publicAddress, amount, new IWhitelistService() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -126,12 +126,20 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		if (kinClient != null && kinClient.hasAccount() && account != null) {
 			sdkVersion = account.getKinSdkVersion();
 		}
-		Logger.log(new Log().withTag("MOOO").text("setMigrationManager with version " + sdkVersion.getVersion()));
 		updateKinClient(migrationManager.getKinClient(sdkVersion));
 	}
 
 	private void updateKinClient(IKinClient kinClient) {
 		this.kinClient = kinClient;
+		final int count = kinClient.getAccountCount();
+
+		for (int i = 0; this.account != null && i < count; i++) {
+			if (this.account.getPublicAddress().equals(kinClient.getAccount(i).getPublicAddress())) {
+				this.account = kinClient.getAccount(i);
+			}
+		}
+
+		reconnectBalanceConnection();
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -419,7 +419,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 	}
 
 	@Override
-	public void fetchBlockchainVersion(final Callback<KinSdkVersion, ApiException> callback) {
+	public void fetchBlockchainVersion(final KinCallback<KinSdkVersion> callback) {
 		if (getBlockchainVersion() == KinSdkVersion.NEW_KIN_SDK) {
 			callback.onResponse(KinSdkVersion.NEW_KIN_SDK);
 		} else {
@@ -432,7 +432,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 				@Override
 				public void onFailure(ApiException exception) {
-					callback.onFailure(exception);
+					callback.onFailure(ErrorUtil.fromApiException(exception));
 				}
 			});
 		}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -344,6 +344,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
+		// TODO: 01/04/2019 if we don't have it locally then why not getting it from the server
 		return local.getBlockchainVersion();
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -128,7 +128,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		if (kinClient != null && kinClient.hasAccount() && account != null) {
 			sdkVersion = account.getKinSdkVersion();
 		}
-		Logger.log(new Log().withTag("MOOO").text("setMigrationManager with version " + sdkVersion.getVersion()));
 		updateKinClient(migrationManager.getKinClient(sdkVersion));
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -142,7 +142,8 @@ public class BlockchainSourceImpl implements BlockchainSource {
 //				final String publicAddress = getPublicAddress();
 			// TODO: 01/04/2019 when login will happen before then change it back to be  getPublicAddress().
 				final String publicAddress = kinClient.getAccount(0).getPublicAddress();
-				remote.getMigrationInfo(publicAddress,
+			// TODO: 01/04/2019 Maybe we can make it more efficient by adding a call to the local storage to check if the account is already migrated(localy)?
+			remote.getMigrationInfo(publicAddress,
 					new Callback<MigrationInfo, ApiException>() {
 						@Override
 						public void onResponse(MigrationInfo migrationInfo) {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -138,9 +138,9 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		// If the account should migrate then migrate it, if not update the kinClient to run on this version.
 		// If we don't have an account then check the server for the current version and update the kinClient to run on this version.
 		if (kinClient.hasAccount()) {
-			// TODO: 01/04/2019 get the real public address
 //			try {
 //				final String publicAddress = getPublicAddress();
+			// TODO: 01/04/2019 when login will happen before then change it back to be  getPublicAddress().
 				final String publicAddress = kinClient.getAccount(0).getPublicAddress();
 				remote.getMigrationInfo(publicAddress,
 					new Callback<MigrationInfo, ApiException>() {
@@ -160,10 +160,8 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 						@Override
 						public void onFailure(ApiException exception) {
-							// TODO: 31/03/2019 handle error like in any other place in the app in this stage
-							int i = 0;
-							i++;
-
+							// TODO: 31/03/2019 handle error like in any other place in the app, find what kind of error...
+							// TODO: 01/04/2019 and if got account not found, which probably means that the account is only created locally then handle it.
 						}
 					});
 //			} catch (BlockchainException e) {
@@ -179,7 +177,7 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 				@Override
 				public void onFailure(ApiException exception) {
-					// TODO: 31/03/2019 handle error like in any other place in the app in this stage
+					// TODO: 31/03/2019 handle error like in any other place in the app, find what kind of error...
 				}
 			});
 		}
@@ -357,7 +355,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		// TODO: 01/04/2019 if we don't have it locally then why not getting it from the server
 		return local.getBlockchainVersion();
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImpl.java
@@ -162,7 +162,6 @@ public class BlockchainSourceImpl implements BlockchainSource {
 		// If the account should migrate then migrate it, if not update the kinClient to run on this version.
 		// If we don't have an account then check the server for the current version and update the kinClient to run on this version.
 		if (kinClient.hasAccount()) {
-			// final String publicAddress = kinClient.getAccount(0).getPublicAddress(); todo remove comment when finish with testings
 			// TODO: 01/04/2019 Maybe we can make it more efficient by adding a call to the local storage to check if the account is already migrated(locally)?
 			if (migrationInfo != null) {
 				startMigrationIfNeeded(migrationInfo, publicAddress, listener);

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import kin.sdk.migration.common.KinSdkVersion;
 
 public class BlockchainSourceLocal implements BlockchainSource.Local {
 
@@ -20,9 +21,9 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 	private static final String ACCOUNT_INDEX_KEY = "account_index_key";
 	private static final String CURRENT_KIN_USER_ID = "current_kin_user_id";
 	private static final String IS_MIGRATED_KEY = "is_migrated_key";
+	private static final String BLOCKCHAIN_VERSION = "blockchain_version";
 
 	private final SharedPreferences blockchainSharedPreferences;
-
 
 	private BlockchainSourceLocal(@NonNull final Context context) {
 		this.blockchainSharedPreferences = context
@@ -39,7 +40,6 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 		}
 		return instance;
 	}
-
 
 	@Override
 	public int getBalance() {
@@ -112,5 +112,16 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 	@Override
 	public void setDidMigrate() {
 		blockchainSharedPreferences.edit().putBoolean(IS_MIGRATED_KEY, true).apply();
+	}
+
+	@Override
+	public KinSdkVersion getBlockchainVersion() {
+		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
+		return KinSdkVersion.valueOf(version);
+	}
+
+	@Override
+	public void setBlockchainVersion(KinSdkVersion version) {
+		blockchainSharedPreferences.edit().putString(BLOCKCHAIN_VERSION, version.getVersion());
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -116,7 +116,9 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, "");
+		// TODO: 01/04/2019 Why do Nitzan want to return OLD VERSION if there is nothing locally
+		 String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
+//		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, "");
 		return KinSdkVersion.get(version);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -117,7 +117,7 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
 		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
-		return KinSdkVersion.valueOf(version);
+		return KinSdkVersion.get(version);
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -116,9 +116,7 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		// TODO: 01/04/2019 Why do Nitzan want to return OLD VERSION if there is nothing locally
-		 String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
-//		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, "");
+		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
 		return KinSdkVersion.get(version);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -116,7 +116,7 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.NEW_KIN_SDK.getVersion());
+		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
 		return KinSdkVersion.get(version);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -124,6 +124,6 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public void setBlockchainVersion(KinSdkVersion version) {
-		blockchainSharedPreferences.edit().putString(BLOCKCHAIN_VERSION, version.getVersion());
+		blockchainSharedPreferences.edit().putString(BLOCKCHAIN_VERSION, version.getVersion()).apply();
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -116,7 +116,7 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.OLD_KIN_SDK.getVersion());
+		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.NEW_KIN_SDK.getVersion());
 		return KinSdkVersion.get(version);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceLocal.java
@@ -116,7 +116,7 @@ public class BlockchainSourceLocal implements BlockchainSource.Local {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() {
-		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, KinSdkVersion.NEW_KIN_SDK.getVersion());
+		String version = blockchainSharedPreferences.getString(BLOCKCHAIN_VERSION, "");
 		return KinSdkVersion.get(version);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -35,7 +35,7 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() throws ApiException {
-		return KinSdkVersion.valueOf(api.getBlockchainVersionSync(""));
+		return KinSdkVersion.get(api.getBlockchainVersionSync(""));
 	}
 
 	@Override
@@ -57,7 +57,7 @@ public class BlockchainSourceRemote implements Remote {
 					executorsUtil.mainThread().execute(new Runnable() {
 						@Override
 						public void run() {
-							callback.onResponse(KinSdkVersion.valueOf(result));
+							callback.onResponse(KinSdkVersion.get(result));
 						}
 					});
 				}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -15,11 +15,11 @@ import kin.sdk.migration.common.KinSdkVersion;
 public class BlockchainSourceRemote implements Remote {
 	private static volatile BlockchainSourceRemote instance;
 
-	private MigrationApi api;
+	private MigrationApi migrationApi;
 	private ExecutorsUtil executorsUtil;
 
 	private BlockchainSourceRemote(@NonNull ExecutorsUtil executorsUtil) {
-		this.api = new MigrationApi();
+		this.migrationApi = new MigrationApi();
 		this.executorsUtil = executorsUtil;
 	}
 
@@ -36,14 +36,14 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() throws ApiException {
-		String version = api.getBlockchainVersionSync("");
+		String version = migrationApi.getBlockchainVersionSync("");
 		return KinSdkVersion.get(version);
 	}
 
 	@Override
 	public void getBlockchainVersion(@NonNull final Callback<KinSdkVersion, ApiException> callback) {
 		try {
-			api.getBlockchainVersionAsync("", new ApiCallback<String>() {
+			migrationApi.getBlockchainVersionAsync("", new ApiCallback<String>() {
 				@Override
 				public void onFailure(final ApiException e, final int statusCode, final Map<String, List<String>> responseHeaders) {
 					executorsUtil.mainThread().execute(new Runnable() {
@@ -76,13 +76,13 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public MigrationInfo getMigrationInfo(@NonNull String publicAddress) throws ApiException {
-		return api.getMigrationInfoSync(publicAddress);
+		return migrationApi.getMigrationInfoSync(publicAddress);
 	}
 
 	@Override
 	public void getMigrationInfo(final String publicAddress, final @NonNull Callback<MigrationInfo, ApiException> callback) {
 		try {
-			api.getMigrationInfoAsync(publicAddress, new ApiCallback<MigrationInfo>() {
+			migrationApi.getMigrationInfoAsync(publicAddress, new ApiCallback<MigrationInfo>() {
 				@Override
 				public void onFailure(final ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
 					executorsUtil.mainThread().execute(new Runnable() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -6,6 +6,7 @@ import com.kin.ecosystem.core.data.blockchain.BlockchainSource.Remote;
 import com.kin.ecosystem.core.network.ApiCallback;
 import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.core.network.api.MigrationApi;
+import com.kin.ecosystem.core.network.model.MigrationInfo;
 import com.kin.ecosystem.core.util.ExecutorsUtil;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() throws ApiException {
+		// TODO: 31/03/2019 also update locally
 		return KinSdkVersion.get(api.getBlockchainVersionSync(""));
 	}
 
@@ -42,6 +44,45 @@ public class BlockchainSourceRemote implements Remote {
 	public void getBlockchainVersion(@NonNull final Callback<KinSdkVersion, ApiException> callback) {
 		try {
 			api.getBlockchainVersionAsync("", new ApiCallback<String>() {
+				@Override
+				public void onFailure(final ApiException e, final int statusCode, final Map<String, List<String>> responseHeaders) {
+					executorsUtil.mainThread().execute(new Runnable() {
+						@Override
+						public void run() {
+							callback.onFailure(e);
+						}
+					});
+				}
+
+				@Override
+				public void onSuccess(final String result, final int statusCode, final Map<String, List<String>> responseHeaders) {
+					executorsUtil.mainThread().execute(new Runnable() {
+						@Override
+						public void run() {
+							callback.onResponse(KinSdkVersion.get(result));
+						}
+					});
+				}
+			});
+		} catch (final ApiException e) {
+			executorsUtil.mainThread().execute(new Runnable() {
+				@Override
+				public void run() {
+					callback.onFailure(e);
+				}
+			});
+		}
+	}
+
+	@Override
+	public MigrationInfo getMigrationInfo(@NonNull String publicAddress) throws ApiException {
+		return api.getMigrationInfoSync(publicAddress);
+	}
+
+	@Override
+	public void getMigrationInfo(final String publicAddress, final @NonNull Callback<MigrationInfo, ApiException> callback) {
+		try {
+			api.getMigrationInfoAsync(publicAddress, new ApiCallback<MigrationInfo>() {
 				@Override
 				public void onFailure(final ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
 					executorsUtil.mainThread().execute(new Runnable() {
@@ -53,11 +94,11 @@ public class BlockchainSourceRemote implements Remote {
 				}
 
 				@Override
-				public void onSuccess(final String result, int statusCode, Map<String, List<String>> responseHeaders) {
+				public void onSuccess(final MigrationInfo result, int statusCode, Map<String, List<String>> responseHeaders) {
 					executorsUtil.mainThread().execute(new Runnable() {
 						@Override
 						public void run() {
-							callback.onResponse(KinSdkVersion.get(result));
+							callback.onResponse(result);
 						}
 					});
 				}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -1,0 +1,74 @@
+package com.kin.ecosystem.core.data.blockchain;
+
+import android.support.annotation.NonNull;
+import com.kin.ecosystem.common.Callback;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource.Remote;
+import com.kin.ecosystem.core.network.ApiCallback;
+import com.kin.ecosystem.core.network.ApiException;
+import com.kin.ecosystem.core.network.api.MigrationApi;
+import com.kin.ecosystem.core.util.ExecutorsUtil;
+import java.util.List;
+import java.util.Map;
+import kin.sdk.migration.common.KinSdkVersion;
+
+public class BlockchainSourceRemote implements Remote {
+	private static volatile BlockchainSourceRemote instance;
+
+	private MigrationApi api;
+	private ExecutorsUtil executorsUtil;
+
+	private BlockchainSourceRemote(@NonNull ExecutorsUtil executorsUtil) {
+		this.api = new MigrationApi();
+		this.executorsUtil = executorsUtil;
+	}
+
+	public static BlockchainSourceRemote getInstance(@NonNull ExecutorsUtil executorsUtil) {
+		if (instance == null) {
+			synchronized (BlockchainSourceRemote.class) {
+				if (instance == null) {
+					instance = new BlockchainSourceRemote(executorsUtil);
+				}
+			}
+		}
+		return instance;
+	}
+
+	@Override
+	public KinSdkVersion getBlockchainVersion() throws ApiException {
+		return KinSdkVersion.valueOf(api.getBlockchainVersionSync(""));
+	}
+
+	@Override
+	public void getBlockchainVersion(@NonNull final Callback<KinSdkVersion, ApiException> callback) {
+		try {
+			api.getBlockchainVersionAsync("", new ApiCallback<String>() {
+				@Override
+				public void onFailure(final ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+					executorsUtil.mainThread().execute(new Runnable() {
+						@Override
+						public void run() {
+							callback.onFailure(e);
+						}
+					});
+				}
+
+				@Override
+				public void onSuccess(final String result, int statusCode, Map<String, List<String>> responseHeaders) {
+					executorsUtil.mainThread().execute(new Runnable() {
+						@Override
+						public void run() {
+							callback.onResponse(KinSdkVersion.valueOf(result));
+						}
+					});
+				}
+			});
+		} catch (final ApiException e) {
+			executorsUtil.mainThread().execute(new Runnable() {
+				@Override
+				public void run() {
+					callback.onFailure(e);
+				}
+			});
+		}
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -35,7 +35,8 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() throws ApiException {
-		return KinSdkVersion.get(api.getBlockchainVersionSync(""));
+		String version = api.getBlockchainVersionSync("");
+		return KinSdkVersion.get(version);
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -36,7 +36,6 @@ public class BlockchainSourceRemote implements Remote {
 
 	@Override
 	public KinSdkVersion getBlockchainVersion() throws ApiException {
-		// TODO: 31/03/2019 check if the caller is update it locally
 		String version = api.getBlockchainVersionSync("");
 		return KinSdkVersion.get(version);
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -11,6 +11,7 @@ import com.kin.ecosystem.common.KinEnvironment;
 import com.kin.ecosystem.core.Log;
 import com.kin.ecosystem.core.Logger;
 import com.kin.ecosystem.core.data.auth.AuthRepository;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.network.ApiClient;
 import com.kin.ecosystem.core.network.model.AuthToken;
 import java.io.IOException;
@@ -37,8 +38,6 @@ public class ConfigurationImpl implements Configuration {
 	private static final String AUTHORIZATION = "Authorization";
 
 	static final String API_VERSION = "v2";
-	// static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
-	static final String BLOCKCHAIN_VERSION = KinSdkVersion.NEW_KIN_SDK.getVersion();
 
 	private static final int NO_TOKEN_ERROR_CODE = 666;
 	private static final String AUTH_TOKEN_COULD_NOT_BE_GENERATED = "AuthToken could not be generated";
@@ -49,6 +48,7 @@ public class ConfigurationImpl implements Configuration {
 
 	private static final Object apiClientLock = new Object();
 	private static ApiClient defaultApiClient;
+	private static BlockchainSource blockchainSource;
 
 	private final KinEnvironment kinEnvironment;
 	private static volatile ConfigurationImpl instance;
@@ -66,6 +66,10 @@ public class ConfigurationImpl implements Configuration {
 				}
 			}
 		}
+	}
+
+	public static void setBlockchainSource(BlockchainSource bcSource) {
+		blockchainSource = bcSource;
 	}
 
 	public static ConfigurationImpl getInstance() {
@@ -130,7 +134,10 @@ public class ConfigurationImpl implements Configuration {
 		apiClient.addDefaultHeader(HEADER_DEVICE_MODEL, Build.MODEL);
 		apiClient.addDefaultHeader(HEADER_DEVICE_MANUFACTURER, Build.MANUFACTURER);
 		apiClient.addDefaultHeader(HEADER_DEVICE_LANGUAGE, getDeviceAcceptedLanguage());
-		apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, BLOCKCHAIN_VERSION);
+
+		if (blockchainSource != null) {
+			apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, blockchainSource.getBlockchainVersion().getVersion());
+		}
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -1,6 +1,7 @@
 package com.kin.ecosystem.core.data.internal;
 
 import static com.kin.ecosystem.core.network.ApiClient.DELETE;
+import static com.kin.ecosystem.core.network.ApiClient.GET;
 import static com.kin.ecosystem.core.network.ApiClient.POST;
 
 import android.os.Build;
@@ -37,14 +38,16 @@ public class ConfigurationImpl implements Configuration {
 	private static final String AUTHORIZATION = "Authorization";
 
 	static final String API_VERSION = "v2";
-	// static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
-	static final String BLOCKCHAIN_VERSION = KinSdkVersion.NEW_KIN_SDK.getVersion();
+	static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
+//	static final String BLOCKCHAIN_VERSION = KinSdkVersion.NEW_KIN_SDK.getVersion();
 
 	private static final int NO_TOKEN_ERROR_CODE = 666;
 	private static final String AUTH_TOKEN_COULD_NOT_BE_GENERATED = "AuthToken could not be generated";
 
 	private static final String USERS_PATH = "/" + API_VERSION + "/users";
 	private static final String LOGOUT_PATH = "/" + API_VERSION + "/users/me/session";
+	private static final String KIN_VERSION_END_PATH = "/blockchain_version";
+	private static final String KIN_MIGRATION_INFO_PATH = "/migration/info";
 	private static final String PREFIX_ANDROID = "android ";
 
 	private static final Object apiClientLock = new Object();
@@ -121,7 +124,8 @@ public class ConfigurationImpl implements Configuration {
 		final String path = originalRequest.url().encodedPath();
 		final String method = originalRequest.method();
 		return path.equals(USERS_PATH) && method.equals(POST) ||
-			path.equals(LOGOUT_PATH) && method.equals(DELETE);
+			path.equals(LOGOUT_PATH) && method.equals(DELETE) ||
+			path.contains(KIN_VERSION_END_PATH) && method.equals(GET);
 	}
 
 	private void addHeaders(ApiClient apiClient) {

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -16,6 +16,7 @@ import com.kin.ecosystem.core.network.model.AuthToken;
 import java.io.IOException;
 import java.util.Locale;
 import kin.ecosystem.core.BuildConfig;
+import kin.sdk.migration.common.KinSdkVersion;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -30,11 +31,13 @@ public class ConfigurationImpl implements Configuration {
 	private static final String HEADER_DEVICE_MANUFACTURER = "X-DEVICE-MANUFACTURER";
 	private static final String HEADER_DEVICE_LANGUAGE = "Accept-Language";
 	private static final String HEADER_OS = "X-OS";
+	private static final String HEADER_BLOCKCHAIN_VERSION = "X-KIN-BLOCKCHAIN-VERSION";
 
 	private static final String BEARER = "Bearer ";
 	private static final String AUTHORIZATION = "Authorization";
 
 	static final String API_VERSION = "v2";
+	static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
 
 	private static final int NO_TOKEN_ERROR_CODE = 666;
 	private static final String AUTH_TOKEN_COULD_NOT_BE_GENERATED = "AuthToken could not be generated";
@@ -126,6 +129,7 @@ public class ConfigurationImpl implements Configuration {
 		apiClient.addDefaultHeader(HEADER_DEVICE_MODEL, Build.MODEL);
 		apiClient.addDefaultHeader(HEADER_DEVICE_MANUFACTURER, Build.MANUFACTURER);
 		apiClient.addDefaultHeader(HEADER_DEVICE_LANGUAGE, getDeviceAcceptedLanguage());
+		apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, BLOCKCHAIN_VERSION);
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -92,7 +92,13 @@ public class ConfigurationImpl implements Configuration {
 				defaultApiClient.addInterceptor(new Interceptor() {
 					@Override
 					public Response intercept(Chain chain) throws IOException {
-						Request originalRequest = chain.request();
+						Request originalRequest = blockchainSource == null ?
+							chain.request() :
+							chain.request() // new request with the BV version header
+								.newBuilder()
+								.addHeader(HEADER_BLOCKCHAIN_VERSION, blockchainSource.getBlockchainVersion().getVersion())
+								.build();
+
 						if (shouldntBeAuthenticated(originalRequest)) {
 							return chain.proceed(originalRequest);
 						} else {
@@ -155,10 +161,6 @@ public class ConfigurationImpl implements Configuration {
 		apiClient.addDefaultHeader(HEADER_DEVICE_MODEL, Build.MODEL);
 		apiClient.addDefaultHeader(HEADER_DEVICE_MANUFACTURER, Build.MANUFACTURER);
 		apiClient.addDefaultHeader(HEADER_DEVICE_LANGUAGE, getDeviceAcceptedLanguage());
-
-		if (blockchainSource != null) {
-			apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, blockchainSource.getBlockchainVersion().getVersion());
-		}
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -49,7 +49,7 @@ public class ConfigurationImpl implements Configuration {
 	private static final String USERS_PATH = "/" + API_VERSION + "/users";
 	private static final String LOGOUT_PATH = "/" + API_VERSION + "/users/me/session";
 	private static final String KIN_VERSION_END_PATH = "/blockchain_version";
-	private static final String KIN_MIGRATION_INFO_PATH = "/migration/info";
+	private static final String KIN_MIGRATION_INFO_PATH = "/" + API_VERSION + "/migration/info";
 	private static final String PREFIX_ANDROID = "android ";
 
 	private static final Object apiClientLock = new Object();
@@ -150,7 +150,8 @@ public class ConfigurationImpl implements Configuration {
 		final String method = originalRequest.method();
 		return path.equals(USERS_PATH) && method.equals(POST) ||
 			path.equals(LOGOUT_PATH) && method.equals(DELETE) ||
-			path.contains(KIN_VERSION_END_PATH) && method.equals(GET);
+			path.contains(KIN_VERSION_END_PATH) && method.equals(GET) ||
+			path.contains(KIN_MIGRATION_INFO_PATH) && method.equals(GET);
 	}
 
 	private void addHeaders(ApiClient apiClient) {

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -162,7 +162,6 @@ public class ConfigurationImpl implements Configuration {
 		apiClient.addDefaultHeader(HEADER_DEVICE_LANGUAGE, getDeviceAcceptedLanguage());
 
 		if (blockchainSource != null) {
-			// TODO: 01/04/2019 there is a problem if there is no version locally
 			apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, blockchainSource.getBlockchainVersion().getVersion());
 		}
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -102,9 +102,16 @@ public class ConfigurationImpl implements Configuration {
 									.header(AUTHORIZATION, BEARER + authToken.getToken())
 									.build();
 
-								Response response = chain.proceed(authorisedRequest);
+								final Response response = chain.proceed(authorisedRequest);
+								final ResponseBody body = response.body();
+								final String bodyString = body.string();
+								final MediaType contentType = body.contentType();
+
 								try {
-									final Object result = defaultApiClient.deserialize(response, Object.class);
+									final Object result = defaultApiClient.deserialize(response
+										.newBuilder()
+										.body(ResponseBody.create(contentType, bodyString))
+										.build(), Object.class);
 								} catch (ApiException e) {
 									KinEcosystemException serviceException = ErrorUtil.fromApiException(e);
 									if (serviceException.getCode() == ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED) {
@@ -112,7 +119,7 @@ public class ConfigurationImpl implements Configuration {
 									}
 								}
 
-								return response;
+								return response.newBuilder().body(ResponseBody.create(contentType, bodyString)).build();
 							} else {
 								// Stop the request from being executed.
 								Logger.log(new Log().withTag("ApiClient").text("No token - response error on client"));

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -117,14 +117,14 @@ public class ConfigurationImpl implements Configuration {
 								final MediaType contentType = body.contentType();
 
 								try {
-									final Object result = defaultApiClient.deserialize(response
+									final Object result = defaultApiClient.handleResponse(response
 										.newBuilder()
 										.body(ResponseBody.create(contentType, bodyString))
 										.build(), Object.class);
 								} catch (ApiException e) {
 									KinEcosystemException serviceException = ErrorUtil.fromApiException(e);
 									if (serviceException.getCode() == ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED) {
-										// TODO: start migration
+										blockchainSource.startMigrationProcess();
 									}
 								}
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -37,7 +37,8 @@ public class ConfigurationImpl implements Configuration {
 	private static final String AUTHORIZATION = "Authorization";
 
 	static final String API_VERSION = "v2";
-	static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
+	// static final String BLOCKCHAIN_VERSION = KinSdkVersion.OLD_KIN_SDK.getVersion();
+	static final String BLOCKCHAIN_VERSION = KinSdkVersion.NEW_KIN_SDK.getVersion();
 
 	private static final int NO_TOKEN_ERROR_CODE = 666;
 	private static final String AUTH_TOKEN_COULD_NOT_BE_GENERATED = "AuthToken could not be generated";

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/ConfigurationImpl.java
@@ -154,6 +154,7 @@ public class ConfigurationImpl implements Configuration {
 		apiClient.addDefaultHeader(HEADER_DEVICE_LANGUAGE, getDeviceAcceptedLanguage());
 
 		if (blockchainSource != null) {
+			// TODO: 01/04/2019 there is a problem if there is no version locally
 			apiClient.addDefaultHeader(HEADER_BLOCKCHAIN_VERSION, blockchainSource.getBlockchainVersion().getVersion());
 		}
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/internal/Environment.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/internal/Environment.java
@@ -13,7 +13,7 @@ class Environment implements KinEnvironment {
 		"GDF42M3IPERQCBLWFEZKQRK77JQ65SCKTU3CW36HZVCX7XX5A5QXZIVK",
 		"https://horizon.kinfederation.com",
 		"Kin Mainnet ; December 2018",
-		"TODO",
+		"https://migration-service.kinmarketplace.com/migrate?address=",
 		"https://api.kinmarketplace.com/" + API_VERSION,
 		"https://cdn.kinmarketplace.com/",
 		"https://kin-bi.appspot.com/eco_");
@@ -35,7 +35,7 @@ class Environment implements KinEnvironment {
 		"GBC3SG6NGTSZ2OMH3FFGB7UVRQWILW367U4GSOOF4TFSZONV42UJXUH7",
 		"https://horizon-testnet.kininfrastructure.com",
 		"Kin Testnet ; December 2018",
-		"TODO",
+		"https://migration-service.kinecosystemtest.com/migrate?address=",
 		"http://api.kinecosystemtest.com/" + API_VERSION,
 		"https://s3.amazonaws.com/assets.kinecosystemtest.com/web-offers/cards-based/index.html",
 		"https://kin-bi.appspot.com/eco_play_");

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/GetOrderPollingCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/GetOrderPollingCall.java
@@ -35,7 +35,7 @@ class GetOrderPollingCall extends Thread {
             if (pollingIndex < DELAY_SECONDS.length) {
                 Order order = remote.getOrderSync(orderID);
                 if (order == null || order.getStatus() == Status.PENDING) {
-                    if(order != null && pollingIndex == DELAYED_ATTEMPTED_NUMBER){
+                    if (order != null && pollingIndex == DELAYED_ATTEMPTED_NUMBER){
                         callback.onResponse(order.status(Status.DELAYED));
                     }
                     sleep(DELAY_SECONDS[pollingIndex] * SEC_IN_MILLI);

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderDataSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderDataSource.java
@@ -22,8 +22,11 @@ public interface OrderDataSource {
 
     void createOrder(@NonNull final String offerID, final KinCallback<OpenOrder> callback);
 
-    void submitOrder(@NonNull final String offerID, @Nullable String content, @NonNull String orderID,
-        final KinCallback<Order> callback);
+	void submitEarnOrder(@NonNull final String offerID, @Nullable String content, @NonNull String orderID,
+		final KinCallback<Order> callback);
+
+	void submitSpendOrder(@NonNull final String offerID, @Nullable String transaction, @NonNull String orderID,
+		final KinCallback<Order> callback);
 
     void cancelOrderSync(@NonNull final String orderID);
 
@@ -64,7 +67,9 @@ public interface OrderDataSource {
 
         void createOrder(@NonNull final String offerID, final Callback<OpenOrder, ApiException> callback);
 
-        void submitOrder(@Nullable String content, @NonNull String orderID, final Callback<Order, ApiException> callback);
+        void submitEarnOrder(@Nullable String content, @NonNull String orderID, final Callback<Order, ApiException> callback);
+
+        void submitSpendOrder(@Nullable String transaction, @NonNull String orderID, final Callback<Order, ApiException> callback);
 
         void cancelOrder(@NonNull final String orderID, final Callback<Void, ApiException> callback);
 

--- a/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
@@ -831,7 +831,12 @@ public class ApiClient {
 		Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames) throws ApiException {
 		updateParamsForAuth(authNames, queryParams, headerParams);
 
-		final String url = buildUrl(path, queryParams, collectionQueryParams);
+		String url = buildUrl(path, queryParams, collectionQueryParams);
+
+		if (url.contains("migration/info")) {
+			url = url.replace("/v2", ""); // TODO: 31/03/2019 remove after testings and discussion
+		}
+
 		final Request.Builder reqBuilder = new Request.Builder().url(url);
 		processHeaderParams(headerParams, reqBuilder);
 

--- a/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
@@ -831,12 +831,12 @@ public class ApiClient {
 		Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames) throws ApiException {
 		updateParamsForAuth(authNames, queryParams, headerParams);
 
-		String url = buildUrl(path, queryParams, collectionQueryParams);
+		final String url = buildUrl(path, queryParams, collectionQueryParams);
 
 		final Request.Builder reqBuilder = new Request.Builder().url(url);
 		processHeaderParams(headerParams, reqBuilder);
 
-		String contentType = (String) headerParams.get("Content-Type");
+		String contentType = headerParams.get("Content-Type");
 		// ensuring a default content type
 		if (contentType == null) {
 			contentType = "application/json";

--- a/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/ApiClient.java
@@ -833,10 +833,6 @@ public class ApiClient {
 
 		String url = buildUrl(path, queryParams, collectionQueryParams);
 
-		if (url.contains("migration/info")) {
-			url = url.replace("/v2", ""); // TODO: 31/03/2019 remove after testings and discussion
-		}
-
 		final Request.Builder reqBuilder = new Request.Builder().url(url);
 		processHeaderParams(headerParams, reqBuilder);
 

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/Api.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/Api.java
@@ -1,0 +1,24 @@
+package com.kin.ecosystem.core.network.api;
+
+import com.kin.ecosystem.core.data.internal.ConfigurationImpl;
+import com.kin.ecosystem.core.network.ApiClient;
+
+/* package */ class Api {
+	protected ApiClient apiClient;
+
+	public Api() {
+		this(ConfigurationImpl.getInstance().getDefaultApiClient());
+	}
+
+	public Api(ApiClient apiClient) {
+		this.apiClient = apiClient;
+	}
+
+	public ApiClient getApiClient() {
+		return apiClient;
+	}
+
+	public void setApiClient(ApiClient apiClient) {
+		this.apiClient = apiClient;
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/AuthApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/AuthApi.java
@@ -10,21 +10,17 @@
  * Do not edit the class manually.
  */
 
-
 package com.kin.ecosystem.core.network.api;
-
 
 import static com.kin.ecosystem.core.network.ApiClient.PATCH;
 
 import com.google.gson.reflect.TypeToken;
-import com.kin.ecosystem.core.data.internal.ConfigurationImpl;
 import com.kin.ecosystem.core.network.ApiCallback;
 import com.kin.ecosystem.core.network.ApiClient;
 import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.core.network.ApiResponse;
 import com.kin.ecosystem.core.network.Pair;
 import com.kin.ecosystem.core.network.model.AccountInfo;
-import com.kin.ecosystem.core.network.model.AuthToken;
 import com.kin.ecosystem.core.network.model.JWT;
 import com.kin.ecosystem.core.network.model.UserProfile;
 import com.kin.ecosystem.core.network.model.UserProperties;
@@ -35,27 +31,7 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.Call;
 
-
-public class AuthApi {
-
-	private ApiClient apiClient;
-
-	public AuthApi() {
-		this(ConfigurationImpl.getInstance().getDefaultApiClient());
-	}
-
-	public AuthApi(ApiClient apiClient) {
-		this.apiClient = apiClient;
-	}
-
-	public ApiClient getApiClient() {
-		return apiClient;
-	}
-
-	public void setApiClient(ApiClient apiClient) {
-		this.apiClient = apiClient;
-	}
-
+public class AuthApi extends Api {
 	/**
 	 * Build call for signIn
 	 *
@@ -168,7 +144,6 @@ public class AuthApi {
 		apiClient.executeAsync(call, localVarReturnType, callback);
 		return call;
 	}
-
 
 	/**
 	 * Build call for getUserProfile

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
@@ -1,15 +1,48 @@
 package com.kin.ecosystem.core.network.api;
 
+import com.google.gson.reflect.TypeToken;
 import com.kin.ecosystem.core.data.auth.AuthRepository;
 import com.kin.ecosystem.core.network.ApiCallback;
 import com.kin.ecosystem.core.network.ApiClient;
 import com.kin.ecosystem.core.network.ApiException;
 import com.kin.ecosystem.core.network.ApiResponse;
+import com.kin.ecosystem.core.network.model.MigrationInfo;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import okhttp3.Call;
 
 public class MigrationApi extends Api {
+
+	public String getBlockchainVersionSync(String X_REQUEST_ID) throws ApiException {
+		Call call = getBlockchainVersion(X_REQUEST_ID);
+		ApiResponse<String> response = apiClient.execute(call);
+		return response.getData();
+	}
+
+	public Call getBlockchainVersionAsync(String X_REQUEST_ID, final ApiCallback<String> callback) throws ApiException {
+		Call call = getBlockchainVersion(X_REQUEST_ID);
+		Type localVarReturnType = new TypeToken<String>() {
+		}.getType();
+		apiClient.executeAsync(call, localVarReturnType, callback);
+		return call;
+	}
+
+	public MigrationInfo getMigrationInfoSync(String publicAddress) throws ApiException {
+		Call call = getMigrationInfo(publicAddress);
+		ApiResponse<MigrationInfo> response = apiClient.execute(call);
+		return response.getData();
+	}
+
+	public Call getMigrationInfoAsync(String publicAddress, final ApiCallback<MigrationInfo> callback)
+		throws ApiException {
+		Call call = getMigrationInfo(publicAddress);
+		apiClient.executeAsync(call, callback);
+		return call;
+
+	}
+
+
 	private Call getBlockchainVersion(String X_REQUEST_ID) throws ApiException {
 		String path = "/applications/" + AuthRepository.getInstance().getAppID() + "/blockchain_version";
 		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
@@ -24,15 +57,17 @@ public class MigrationApi extends Api {
 				localVarHeaderParams, null, null);
 	}
 
-	public String getBlockchainVersionSync(String X_REQUEST_ID) throws ApiException {
-		Call call = getBlockchainVersion(X_REQUEST_ID);
-		ApiResponse<String> response = apiClient.execute(call);
-		return response.getData();
+	private Call getMigrationInfo(String publicAddress) throws ApiException {
+		String path = "/migration/info/" + AuthRepository.getInstance().getAppID() + "/" + publicAddress;
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+		localVarHeaderParams.put("X-REQUEST-ID", apiClient.parameterToString(""));
+
+		return apiClient
+			.buildCall(path, ApiClient.GET, null, null,
+				null,
+				localVarHeaderParams, null, null);
 	}
 
-	public Call getBlockchainVersionAsync(String X_REQUEST_ID, final ApiCallback<String> callback) throws ApiException {
-		Call call = getBlockchainVersion(X_REQUEST_ID);
-		apiClient.executeAsync(call, callback);
-		return call;
-	}
+
 }

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
@@ -1,0 +1,38 @@
+package com.kin.ecosystem.core.network.api;
+
+import com.kin.ecosystem.core.data.auth.AuthRepository;
+import com.kin.ecosystem.core.network.ApiCallback;
+import com.kin.ecosystem.core.network.ApiClient;
+import com.kin.ecosystem.core.network.ApiException;
+import com.kin.ecosystem.core.network.ApiResponse;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.Call;
+
+public class MigrationApi extends Api {
+	private Call getBlockchainVersion(String X_REQUEST_ID) throws ApiException {
+		String path = "/applications/" + AuthRepository.getInstance().getAppID() + "/blockchain_version";
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+
+		if (X_REQUEST_ID != null) {
+			localVarHeaderParams.put("X-REQUEST-ID", apiClient.parameterToString(X_REQUEST_ID));
+		}
+
+		return apiClient
+			.buildCall(path, ApiClient.GET, null, null,
+				null,
+				localVarHeaderParams, null, null);
+	}
+
+	public String getBlockchainVersionSync(String X_REQUEST_ID) throws ApiException {
+		Call call = getBlockchainVersion(X_REQUEST_ID);
+		ApiResponse<String> response = apiClient.execute(call);
+		return response.getData();
+	}
+
+	public Call getBlockchainVersionAsync(String X_REQUEST_ID, final ApiCallback<String> callback) throws ApiException {
+		Call call = getBlockchainVersion(X_REQUEST_ID);
+		apiClient.executeAsync(call, callback);
+		return call;
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
@@ -37,7 +37,9 @@ public class MigrationApi extends Api {
 	public Call getMigrationInfoAsync(String publicAddress, final ApiCallback<MigrationInfo> callback)
 		throws ApiException {
 		Call call = getMigrationInfo(publicAddress);
-		apiClient.executeAsync(call, callback);
+		Type localVarReturnType = new TypeToken<MigrationInfo>() {
+		}.getType();
+		apiClient.executeAsync(call, localVarReturnType, callback);
 		return call;
 
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/MigrationApi.java
@@ -26,7 +26,7 @@ public class MigrationApi extends Api {
 
 	public String getBlockchainVersionSync(String X_REQUEST_ID) throws ApiException {
 		Call call = getBlockchainVersion(X_REQUEST_ID);
-		ApiResponse<String> response = apiClient.execute(call);
+		ApiResponse<String> response = apiClient.execute(call, String.class);
 		return response.getData();
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/OffersApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/OffersApi.java
@@ -17,26 +17,7 @@ import java.util.Map;
 import okhttp3.Call;
 
 
-public class OffersApi {
-    private ApiClient apiClient;
-
-    public OffersApi() {
-        this(ConfigurationImpl.getInstance().getDefaultApiClient());
-    }
-
-    public OffersApi(ApiClient apiClient) {
-        this.apiClient = apiClient;
-    }
-
-    public ApiClient getApiClient() {
-        return apiClient;
-    }
-
-    public void setApiClient(ApiClient apiClient) {
-        this.apiClient = apiClient;
-    }
-
-
+public class OffersApi extends Api {
     /**
      * Build call for getOffers
      *

--- a/core/src/main/java/com/kin/ecosystem/core/network/api/OrdersApi.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/api/OrdersApi.java
@@ -10,7 +10,6 @@ package com.kin.ecosystem.core.network.api;/*
  * Do not edit the class manually.
  */
 
-
 import com.google.gson.reflect.TypeToken;
 import com.kin.ecosystem.core.data.internal.ConfigurationImpl;
 import com.kin.ecosystem.core.network.ApiCallback;
@@ -24,6 +23,7 @@ import com.kin.ecosystem.core.network.model.ExternalOrderRequest;
 import com.kin.ecosystem.core.network.model.OpenOrder;
 import com.kin.ecosystem.core.network.model.Order;
 import com.kin.ecosystem.core.network.model.OrderList;
+import com.kin.ecosystem.core.network.model.SpendOrderPayload;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,28 +31,7 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.Call;
 
-
-public class OrdersApi {
-
-	private ApiClient apiClient;
-
-	public OrdersApi() {
-		this(ConfigurationImpl.getInstance().getDefaultApiClient());
-	}
-
-	public OrdersApi(ApiClient apiClient) {
-		this.apiClient = apiClient;
-	}
-
-	public ApiClient getApiClient() {
-		return apiClient;
-	}
-
-	public void setApiClient(ApiClient apiClient) {
-		this.apiClient = apiClient;
-	}
-
-
+public class OrdersApi extends Api {
 	/**
 	 * Build call for cancelOrder
 	 *
@@ -268,7 +247,6 @@ public class OrdersApi {
 		apiClient.executeAsync(call, localVarReturnType, callback);
 		return call;
 	}
-
 
 	/**
 	 * Build call for createExternalOrder
@@ -768,12 +746,12 @@ public class OrdersApi {
 	 * @return Call to execute
 	 * @throws ApiException If fail to serialize the request body object
 	 */
-	public Call submitOrderCall(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
+	public Call submitEarnOrderCall(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
 		Object localVarPostBody = earnsubmission;
 
 		// create path and map variables
 		String localVarPath = "/orders/{order_id}"
-			.replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId.toString()));
+			.replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId));
 
 		List<Pair> localVarQueryParams = new ArrayList<Pair>();
 		List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -799,8 +777,6 @@ public class OrdersApi {
 		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 		localVarHeaderParams.put("Content-Type", localVarContentType);
 
-
-
 		String[] localVarAuthNames = new String[]{};
 		return apiClient
 			.buildCall(localVarPath, ApiClient.POST, localVarQueryParams, localVarCollectionQueryParams,
@@ -809,7 +785,7 @@ public class OrdersApi {
 	}
 
 	@SuppressWarnings("rawtypes")
-	private Call submitOrderValidateBeforeCall(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
+	private Call submitEarnOrderValidateBeforeCall(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
 
 		// verify the required parameter 'earnsubmission' is set
 		if (earnsubmission == null) {
@@ -826,7 +802,7 @@ public class OrdersApi {
 			throw new ApiException("Missing the required parameter 'X_REQUEST_ID' when calling submitOrder(Async)");
 		}
 
-		return submitOrderCall(earnsubmission, orderId, X_REQUEST_ID);
+		return submitEarnOrderCall(earnsubmission, orderId, X_REQUEST_ID);
 
 
 	}
@@ -841,8 +817,8 @@ public class OrdersApi {
 	 * @return Order
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 */
-	public Order submitOrder(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
-		ApiResponse<Order> resp = submitOrderWithHttpInfo(earnsubmission, orderId, X_REQUEST_ID);
+	public Order submitEarnOrder(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID) throws ApiException {
+		ApiResponse<Order> resp = submitEarnOrderWithHttpInfo(earnsubmission, orderId, X_REQUEST_ID);
 		return resp.getData();
 	}
 
@@ -856,9 +832,9 @@ public class OrdersApi {
 	 * @return ApiResponse&lt;Order&gt;
 	 * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
 	 */
-	public ApiResponse<Order> submitOrderWithHttpInfo(EarnSubmission earnsubmission, String orderId,
+	public ApiResponse<Order> submitEarnOrderWithHttpInfo(EarnSubmission earnsubmission, String orderId,
 		String X_REQUEST_ID) throws ApiException {
-		Call call = submitOrderValidateBeforeCall(earnsubmission, orderId, X_REQUEST_ID);
+		Call call = submitEarnOrderValidateBeforeCall(earnsubmission, orderId, X_REQUEST_ID);
 		Type localVarReturnType = new TypeToken<Order>() {
 		}.getType();
 		return apiClient.execute(call, localVarReturnType);
@@ -875,10 +851,78 @@ public class OrdersApi {
 	 * @return The request call
 	 * @throws ApiException If fail to process the API call, e.g. serializing the request body object
 	 */
-	public Call submitOrderAsync(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID,
+	public Call submitEarnOrderAsync(EarnSubmission earnsubmission, String orderId, String X_REQUEST_ID,
 		final ApiCallback<Order> callback) throws ApiException {
 
-		Call call = submitOrderValidateBeforeCall(earnsubmission, orderId, X_REQUEST_ID);
+		Call call = submitEarnOrderValidateBeforeCall(earnsubmission, orderId, X_REQUEST_ID);
+		Type localVarReturnType = new TypeToken<Order>() {
+		}.getType();
+		apiClient.executeAsync(call, localVarReturnType, callback);
+		return call;
+	}
+
+	public Call submitSpendOrderCall(SpendOrderPayload payload, String orderId, String X_REQUEST_ID) throws ApiException {
+		Object localVarPostBody = payload;
+
+		// create path and map variables
+		String localVarPath = "/orders/{order_id}"
+			.replaceAll("\\{" + "order_id" + "\\}", apiClient.escapeString(orderId));
+
+		List<Pair> localVarQueryParams = new ArrayList<Pair>();
+		List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+
+		Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+		if (X_REQUEST_ID != null) {
+			localVarHeaderParams.put("X-REQUEST-ID", apiClient.parameterToString(X_REQUEST_ID));
+		}
+
+		Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+		final String[] localVarAccepts = {
+			"application/json", "application/json", "application/json"
+		};
+		final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+		if (localVarAccept != null) {
+			localVarHeaderParams.put("Accept", localVarAccept);
+		}
+
+		final String[] localVarContentTypes = {
+			"application/json"
+		};
+		final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+		localVarHeaderParams.put("Content-Type", localVarContentType);
+
+		String[] localVarAuthNames = new String[]{};
+		return apiClient
+			.buildCall(localVarPath, ApiClient.POST, localVarQueryParams, localVarCollectionQueryParams,
+				localVarPostBody,
+				localVarHeaderParams, localVarFormParams, localVarAuthNames);
+	}
+
+	private Call submitSpendOrderValidateBeforeCall(SpendOrderPayload payload, String orderId, String X_REQUEST_ID) throws ApiException {
+
+		// verify the required parameter 'payload' is set
+		if (payload == null) {
+			throw new ApiException("Missing the required parameter 'payload' when calling submitOrder(Async)");
+		}
+
+		// verify the required parameter 'orderId' is set
+		if (orderId == null) {
+			throw new ApiException("Missing the required parameter 'orderId' when calling submitOrder(Async)");
+		}
+
+		// verify the required parameter 'X_REQUEST_ID' is set
+		if (X_REQUEST_ID == null) {
+			throw new ApiException("Missing the required parameter 'X_REQUEST_ID' when calling submitOrder(Async)");
+		}
+
+		return submitSpendOrderCall(payload, orderId, X_REQUEST_ID);
+	}
+
+	public Call submitSpendOrderAsync(SpendOrderPayload payload, String orderId, String X_REQUEST_ID,
+		final ApiCallback<Order> callback) throws ApiException {
+
+		Call call = submitSpendOrderValidateBeforeCall(payload, orderId, X_REQUEST_ID);
 		Type localVarReturnType = new TypeToken<Order>() {
 		}.getType();
 		apiClient.executeAsync(call, localVarReturnType, callback);

--- a/core/src/main/java/com/kin/ecosystem/core/network/model/MigrationInfo.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/model/MigrationInfo.java
@@ -1,0 +1,20 @@
+package com.kin.ecosystem.core.network.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class MigrationInfo {
+
+	@SerializedName("app_blockchain_version")
+	private String blockchainVersion;
+
+	@SerializedName("should_migrate")
+	private boolean shouldMigrate;
+
+	public String getBlockchainVersion() {
+		return blockchainVersion;
+	}
+
+	public boolean shouldMigrate() {
+		return shouldMigrate;
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/network/model/MigrationInfo.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/model/MigrationInfo.java
@@ -10,11 +10,18 @@ public class MigrationInfo {
 	@SerializedName("should_migrate")
 	private boolean shouldMigrate;
 
+	@SerializedName("restore_allowed")
+	private boolean isRestorable;
+
 	public String getBlockchainVersion() {
 		return blockchainVersion;
 	}
 
 	public boolean shouldMigrate() {
 		return shouldMigrate;
+	}
+
+	public boolean isRestorable() {
+		return isRestorable;
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/network/model/SpendOrderPayload.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/model/SpendOrderPayload.java
@@ -1,7 +1,7 @@
 package com.kin.ecosystem.core.network.model;
 
 import com.google.gson.annotations.SerializedName;
-import java.util.Objects;
+import com.kin.ecosystem.core.util.StringUtil;
 
 public class SpendOrderPayload {
 	@SerializedName("transaction")
@@ -34,12 +34,12 @@ public class SpendOrderPayload {
 			return false;
 		}
 		SpendOrderPayload payload = (SpendOrderPayload) o;
-		return Objects.equals(this.transaction, payload.transaction);
+		return this.transaction.equals(payload.transaction);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(transaction);
+		return transaction.hashCode();
 	}
 
 	@Override
@@ -47,19 +47,8 @@ public class SpendOrderPayload {
 		StringBuilder sb = new StringBuilder();
 		sb.append("class SpendOrderPayload {\n");
 
-		sb.append("    transaction: ").append(toIndentedString(transaction)).append("\n");
+		sb.append("    transaction: ").append(StringUtil.toIndentedString(transaction)).append("\n");
 		sb.append("}");
 		return sb.toString();
-	}
-
-	/**
-	 * Convert the given object to string with each line indented by 4 spaces
-	 * (except the first line).
-	 */
-	private String toIndentedString(java.lang.Object o) {
-		if (o == null) {
-			return "null";
-		}
-		return o.toString().replace("\n", "\n    ");
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/network/model/SpendOrderPayload.java
+++ b/core/src/main/java/com/kin/ecosystem/core/network/model/SpendOrderPayload.java
@@ -1,0 +1,65 @@
+package com.kin.ecosystem.core.network.model;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Objects;
+
+public class SpendOrderPayload {
+	@SerializedName("transaction")
+	private String transaction = null;
+
+	public SpendOrderPayload transaction(String transaction) {
+		this.transaction = transaction;
+		return this;
+	}
+
+	/**
+	 * json encoded payload related to the spend offer
+	 *
+	 * @return transaction
+	 **/
+	public String getTransaction() {
+		return transaction;
+	}
+
+	public void setTransaction(String transaction) {
+		this.transaction = transaction;
+	}
+
+	@Override
+	public boolean equals(java.lang.Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SpendOrderPayload payload = (SpendOrderPayload) o;
+		return Objects.equals(this.transaction, payload.transaction);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(transaction);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("class SpendOrderPayload {\n");
+
+		sb.append("    transaction: ").append(toIndentedString(transaction)).append("\n");
+		sb.append("}");
+		return sb.toString();
+	}
+
+	/**
+	 * Convert the given object to string with each line indented by 4 spaces
+	 * (except the first line).
+	 */
+	private String toIndentedString(java.lang.Object o) {
+		if (o == null) {
+			return "null";
+		}
+		return o.toString().replace("\n", "\n    ");
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
@@ -32,7 +32,7 @@ public class ErrorUtil {
 	private static final String ACCOUNT_IS_NOT_LOGGED_IN = "Account is not logged in, please call Kin.login(...) first.";
 	private static final String ACCOUNT_NOT_FOUND = "Account not found";
 	private static final String ACCOUNT_HAS_NO_WALLET = "Account has no wallet";
-	private static final String MIGRATION_NEEDED = "Migration is needed";
+	private static final String MIGRATION_NEEDED = "Migration to new kin blockchain is needed";
 	private static final String WALLET_WAS_NOT_CREATED_IN_THIS_APP = "This wallet was not created in this app";
 
 
@@ -42,14 +42,14 @@ public class ErrorUtil {
 	private static final int ERROR_CODE_NOT_FOUND = 404;
 	private static final int ERROR_CODE_REQUEST_TIMEOUT = 408;
 	public static final int ERROR_CODE_CONFLICT = 409;
-	public static final int ERROR_CODE_GONE = 410;
+	private static final int ERROR_CODE_GONE = 410;
 	private static final int ERROR_CODE_INTERNAL_SERVER_ERROR = 500;
 	private static final int ERROR_CODE_TRANSACTION_FAILED_ERROR = 700;
 
 	private static final int ERROR_CODE_NO_SUCH_USER = 4046;
 	private static final int ERROR_CODE_USER_HAS_NO_WALLET = 4095;
 	public static final int ERROR_CODE_EXTERNAL_ORDER_ALREADY_COMPLETED = 4091;
-	public static final int ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED = 4101;
+	private static final int ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED = 4101;
 
 	public static KinEcosystemException fromApiException(ApiException apiException) {
 		if (apiException == null) {
@@ -57,6 +57,7 @@ public class ErrorUtil {
 		} else {
 			final int apiCode = apiException.getCode();
 			Error error = apiException.getResponseBody();
+
 			switch (apiCode) {
 				case ERROR_CODE_BAD_REQUEST:
 				case ERROR_CODE_UNAUTHORIZED:
@@ -80,12 +81,11 @@ public class ErrorUtil {
 					return createUnknownServiceException(apiException);
 				case ERROR_CODE_GONE:
 					if (error != null) {
-						switch (error.getCode()) {
-							case ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED:
-								return new ServiceException(ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED,
-									MIGRATION_NEEDED, apiException);
+						if (error.getCode() == ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED) {
+							return new ServiceException(ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED, MIGRATION_NEEDED, apiException);
 						}
 					}
+					return createUnknownServiceException(apiException, error);
 				case ERROR_CODE_REQUEST_TIMEOUT:
 					return new ServiceException(ServiceException.TIMEOUT_ERROR, THE_OPERATION_TIMED_OUT, apiException);
 				case ClientException.INTERNAL_INCONSISTENCY:
@@ -94,13 +94,22 @@ public class ErrorUtil {
 				case ServiceException.WALLET_WAS_NOT_CREATED_IN_THIS_APP:
 					return createWalletWasNotCreatedInThisAppException();
 				default:
-					return createUnknownServiceException(apiException);
+					return createUnknownServiceException(apiException, error);
 			}
 		}
 	}
 
 	private static KinEcosystemException createUnknownServiceException(@Nullable Throwable throwable) {
-		final String msg = getMessage(throwable);
+		return createUnknownServiceException(throwable, null);
+	}
+
+	private static KinEcosystemException createUnknownServiceException(@Nullable Throwable throwable, @Nullable Error error) {
+		String msg = getMessage(throwable);
+
+		if (error != null) {
+			msg += " (" + error.getCode() + ")";
+		}
+
 		return new ServiceException(ServiceException.SERVICE_ERROR, msg, throwable);
 	}
 

--- a/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
@@ -33,6 +33,7 @@ public class ErrorUtil {
 	private static final String ACCOUNT_NOT_FOUND = "Account not found";
 	private static final String ACCOUNT_HAS_NO_WALLET = "Account has no wallet";
 	private static final String MIGRATION_NEEDED = "Migration is needed";
+	private static final String WALLET_WAS_NOT_CREATED_IN_THIS_APP = "This wallet was not created in this app";
 
 
 	// Server Error codes
@@ -90,6 +91,8 @@ public class ErrorUtil {
 				case ClientException.INTERNAL_INCONSISTENCY:
 					return new ClientException(ClientException.INTERNAL_INCONSISTENCY, THE_OPERATION_TIMED_OUT,
 						apiException);
+				case ServiceException.WALLET_WAS_NOT_CREATED_IN_THIS_APP:
+					return createWalletWasNotCreatedInThisAppException();
 				default:
 					return createUnknownServiceException(apiException);
 			}
@@ -176,4 +179,10 @@ public class ErrorUtil {
 
 		return exception;
 	}
+
+	public static ServiceException createWalletWasNotCreatedInThisAppException() {
+		return new ServiceException(ServiceException.WALLET_WAS_NOT_CREATED_IN_THIS_APP,
+			WALLET_WAS_NOT_CREATED_IN_THIS_APP, null);
+	}
+
 }

--- a/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
@@ -32,6 +32,7 @@ public class ErrorUtil {
 	private static final String ACCOUNT_IS_NOT_LOGGED_IN = "Account is not logged in, please call Kin.login(...) first.";
 	private static final String ACCOUNT_NOT_FOUND = "Account not found";
 	private static final String ACCOUNT_HAS_NO_WALLET = "Account has no wallet";
+	private static final String MIGRATION_NEEDED = "Migration is needed";
 
 
 	// Server Error codes
@@ -40,12 +41,14 @@ public class ErrorUtil {
 	private static final int ERROR_CODE_NOT_FOUND = 404;
 	private static final int ERROR_CODE_REQUEST_TIMEOUT = 408;
 	public static final int ERROR_CODE_CONFLICT = 409;
+	public static final int ERROR_CODE_GONE = 410;
 	private static final int ERROR_CODE_INTERNAL_SERVER_ERROR = 500;
 	private static final int ERROR_CODE_TRANSACTION_FAILED_ERROR = 700;
 
 	private static final int ERROR_CODE_NO_SUCH_USER = 4046;
 	private static final int ERROR_CODE_USER_HAS_NO_WALLET = 4095;
 	public static final int ERROR_CODE_EXTERNAL_ORDER_ALREADY_COMPLETED = 4091;
+	public static final int ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED = 4101;
 
 	public static KinEcosystemException fromApiException(ApiException apiException) {
 		if (apiException == null) {
@@ -74,6 +77,14 @@ public class ErrorUtil {
 							getMessageOrDefault(error, THE_ECOSYSTEM_SERVER_RETURNED_AN_ERROR), apiException);
 					}
 					return createUnknownServiceException(apiException);
+				case ERROR_CODE_GONE:
+					if (error != null) {
+						switch (error.getCode()) {
+							case ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED:
+								return new ServiceException(ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED,
+									MIGRATION_NEEDED, apiException);
+						}
+					}
 				case ERROR_CODE_REQUEST_TIMEOUT:
 					return new ServiceException(ServiceException.TIMEOUT_ERROR, THE_OPERATION_TIMED_OUT, apiException);
 				case ClientException.INTERNAL_INCONSISTENCY:
@@ -81,7 +92,6 @@ public class ErrorUtil {
 						apiException);
 				default:
 					return createUnknownServiceException(apiException);
-
 			}
 		}
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
@@ -105,7 +105,6 @@ public class ErrorUtil {
 			? throwable.getCause().getMessage() : ECOSYSTEM_SDK_ENCOUNTERED_AN_UNEXPECTED_ERROR;
 	}
 
-
 	public static ApiException createOrderTimeoutException() {
 		final String errorTitle = "Time out";
 		final String errorMsg = "order timed out";

--- a/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
+++ b/core/src/test/java/com/kin/ecosystem/core/data/order/OrderRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -197,8 +198,8 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(openOrder, orderRepository.getOpenOrder().getValue());
 
 		// Submit Order
-		orderRepository.submitOrder(order.getOfferId(), "", order.getOrderId(), orderCallback);
-		verify(remote).submitOrder(anyString(), anyString(), submitOrderCapture.capture());
+		orderRepository.submitEarnOrder(order.getOfferId(), "", order.getOrderId(), orderCallback);
+		verify(remote).submitEarnOrder(anyString(), anyString(), submitOrderCapture.capture());
 		verify(blockchainSource).addPaymentObservable(paymentCapture.capture());
 
 		when(order.getStatus()).thenReturn(Status.PENDING);
@@ -239,8 +240,8 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(openOrder, orderRepository.getOpenOrder().getValue());
 
 		// Submit Order
-		orderRepository.submitOrder(order.getOfferId(), "", order.getOrderId(), orderCallback);
-		verify(remote).submitOrder(anyString(), anyString(), submitOrderCapture.capture());
+		orderRepository.submitSpendOrder(order.getOfferId(), null, order.getOrderId(), orderCallback);
+		verify(remote).submitSpendOrder((String) isNull(), anyString(), submitOrderCapture.capture());
 		verify(blockchainSource).addPaymentObservable(paymentCapture.capture());
 
 		when(order.getStatus()).thenReturn(Status.PENDING);
@@ -280,8 +281,8 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(openOrder, orderRepository.getOpenOrder().getValue());
 
 		// Submit Order
-		orderRepository.submitOrder(order.getOfferId(), "", order.getOrderId(), orderCallback);
-		verify(remote).submitOrder(anyString(), anyString(), submitOrderCapture.capture());
+		orderRepository.submitSpendOrder(order.getOfferId(), null, order.getOrderId(), orderCallback);
+		verify(remote).submitSpendOrder((String) isNull(), anyString(), submitOrderCapture.capture());
 		verify(blockchainSource).addPaymentObservable(paymentCapture.capture());
 
 		when(order.getStatus()).thenReturn(Status.PENDING);
@@ -307,6 +308,8 @@ public class OrderRepositoryTest extends BaseTestClass {
 		KinCallback<Order> orderCallback = mock(KinCallback.class);
 		ArgumentCaptor<Callback<Order, ApiException>> submitOrderCapture = ArgumentCaptor.forClass(Callback.class);
 
+		when(order.getOfferType()).thenReturn(OfferType.SPEND);
+
 		// Create Order
 		orderRepository.createOrder(order.getOfferId(), openOrderCallback);
 		verify(remote).createOrder(anyString(), createOrderCapture.capture());
@@ -314,8 +317,8 @@ public class OrderRepositoryTest extends BaseTestClass {
 		assertEquals(openOrder, orderRepository.getOpenOrder().getValue());
 
 		// Submit Order
-		orderRepository.submitOrder(order.getOfferId(), "", order.getOrderId(), orderCallback);
-		verify(remote).submitOrder(anyString(), anyString(), submitOrderCapture.capture());
+		orderRepository.submitSpendOrder(order.getOfferId(), null, order.getOrderId(), orderCallback);
+		verify(remote).submitSpendOrder((String) isNull(), anyString(), submitOrderCapture.capture());
 
 		submitOrderCapture.getValue().onFailure(getApiException());
 		verify(orderCallback).onFailure(any(KinEcosystemException.class));
@@ -387,9 +390,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 			}
 
 			@Override
-			public void onFailure(KinEcosystemException exception) {
-
-			}
+			public void onFailure(KinEcosystemException exception) {}
 		});
 		Thread.sleep(500);
 		ShadowLooper.runUiThreadTasks();
@@ -453,7 +454,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		Thread.sleep(500);
 		ShadowLooper.runUiThreadTasks();
 		verify(blockchainSource, never()).addPaymentObservable(any(Observer.class));
-		verify(remote, never()).submitOrder(anyString(), anyString(), any(Callback.class));
+		verify(remote, never()).submitSpendOrder((String) isNull(), anyString(), any(Callback.class));
 		assertNull(orderRepository.getOrderWatcher().getValue());
 
 		countDownLatch.await(1000, TimeUnit.MICROSECONDS);
@@ -483,7 +484,7 @@ public class OrderRepositoryTest extends BaseTestClass {
 		Thread.sleep(500);
 		ShadowLooper.runUiThreadTasks();
 		verify(blockchainSource, never()).addPaymentObservable(any(Observer.class));
-		verify(remote, never()).submitOrder(anyString(), anyString(), any(Callback.class));
+		verify(remote, never()).submitSpendOrder((String) isNull(), anyString(), any(Callback.class));
 		assertNull(orderRepository.getOrderWatcher().getValue());
 
 		countDownLatch.await(500, TimeUnit.MICROSECONDS);

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
@@ -68,7 +68,7 @@ class BlockchainSourceImplTest() : BaseTestClass() {
     }
 
     private val migrationManager: MigrationManager = mock {
-        on { getKinClient(KinSdkVersion.NEW_KIN_SDK) } doAnswer { kinClient }
+        on { getKinClient( anyOrNull()) } doAnswer { kinClient }
     }
 
     private val balanceObj: IBalance = mock()

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
@@ -10,6 +10,7 @@ import com.kin.ecosystem.core.data.auth.AuthDataSource
 import com.nhaarman.mockitokotlin2.*
 import kin.ecosystem.test.base.BaseTestClass
 import kin.sdk.migration.MigrationManager
+import kin.sdk.migration.common.KinSdkVersion
 import kin.sdk.migration.common.interfaces.*
 import kin.utils.Request
 import kin.utils.ResultCallback
@@ -41,6 +42,9 @@ class BlockchainSourceImplTest() : BaseTestClass() {
     private val local: BlockchainSource.Local = mock {
         on { accountIndex } doAnswer { BlockchainSourceLocal.NOT_EXIST }
     }
+
+    private val remote: BlockchainSource.Remote = mock {}
+
     private val authRepository: AuthDataSource = mock {
         on { ecosystemUserID } doAnswer { KIN_USER_ID_A }
     }
@@ -64,7 +68,7 @@ class BlockchainSourceImplTest() : BaseTestClass() {
     }
 
     private val migrationManager: MigrationManager = mock {
-        on { currentKinClient } doAnswer { kinClient }
+        on { getKinClient(KinSdkVersion.NEW_KIN_SDK) } doAnswer { kinClient }
     }
 
     private val balanceObj: IBalance = mock()
@@ -83,7 +87,7 @@ class BlockchainSourceImplTest() : BaseTestClass() {
         val instance = BlockchainSourceImpl::class.java.getDeclaredField("instance")
         instance.isAccessible = true
         instance.set(null, null)
-        BlockchainSourceImpl.init(eventLogger, local, authRepository, BlockchainSourceRemote.getInstance(instance.executorsUtil))
+        BlockchainSourceImpl.init(eventLogger, local, remote, authRepository)
         BlockchainSourceImpl.getInstance().setMigrationManager(migrationManager)
         blockchainSource = BlockchainSourceImpl.getInstance()
     }

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/blockchain/BlockchainSourceImplTest.kt
@@ -83,7 +83,7 @@ class BlockchainSourceImplTest() : BaseTestClass() {
         val instance = BlockchainSourceImpl::class.java.getDeclaredField("instance")
         instance.isAccessible = true
         instance.set(null, null)
-        BlockchainSourceImpl.init(eventLogger, local, authRepository)
+        BlockchainSourceImpl.init(eventLogger, local, authRepository, BlockchainSourceRemote.getInstance(instance.executorsUtil))
         BlockchainSourceImpl.getInstance().setMigrationManager(migrationManager)
         blockchainSource = BlockchainSourceImpl.getInstance()
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     gsonVersion = '2.8.2'
     hamcrestVersion = '1.3'
     zxingVersion = '3.3.3'
-    kinMigrationVersion = 'master-SNAPSHOT'
+    kinMigrationVersion = 'ab91f897fc'
     kotlinVersion = kotlin_version
 
     //Packages

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     gsonVersion = '2.8.2'
     hamcrestVersion = '1.3'
     zxingVersion = '3.3.3'
-    kinMigrationVersion = 'ab91f897fc'
+    kinMigrationVersion = '1.0.6'
     kotlinVersion = kotlin_version
 
     //Packages

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -202,7 +202,7 @@ public class Kin {
 	}
 
 	private static void internalLogin(@NonNull final String jwt, final KinCallback<Void> loginCallback) {
-		MigrationManager migrationManager = createMigrationManager(getKinContext(), "amit"/*AuthRepository.getInstance().getAppID()*/);
+		MigrationManager migrationManager = createMigrationManager(getKinContext(), "nitz"/*AuthRepository.getInstance().getAppID()*/);
 
 		try {
 			checkInstanceNotNull();

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -202,7 +202,7 @@ public class Kin {
 	}
 
 	private static void internalLogin(@NonNull final String jwt, final KinCallback<Void> loginCallback) {
-		MigrationManager migrationManager = createMigrationManager(getKinContext(), "nitz"/*AuthRepository.getInstance().getAppID()*/);
+		MigrationManager migrationManager = createMigrationManager(getKinContext(), "amit"/*AuthRepository.getInstance().getAppID()*/);
 
 		try {
 			checkInstanceNotNull();

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -123,6 +123,8 @@ public class Kin {
 			BlockchainSourceImpl.init(eventLogger, BlockchainSourceLocal.getInstance(getKinContext()),
 				AuthRepository.getInstance());
 
+			ConfigurationImpl.setBlockchainSource(BlockchainSourceImpl.getInstance());
+
 			EventCommonDataUtil.setBaseData(getKinContext());
 
 			AccountManagerImpl

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -121,7 +121,7 @@ public class Kin {
 				.init(AuthLocalData.getInstance(getKinContext()), AuthRemoteData.getInstance(instance.executorsUtil));
 
 			BlockchainSourceImpl.init(eventLogger, BlockchainSourceLocal.getInstance(getKinContext()),
-				AuthRepository.getInstance());
+				BlockchainSourceRemote.getInstance(instance.executorsUtil), AuthRepository.getInstance());
 
 			EventCommonDataUtil.setBaseData(getKinContext());
 
@@ -200,7 +200,7 @@ public class Kin {
 	}
 
 	private static void internalLogin(@NonNull final String jwt, final KinCallback<Void> loginCallback) {
-		MigrationManager migrationManager = createMigrationManager(getKinContext(), AuthRepository.getInstance().getAppID());
+		MigrationManager migrationManager = createMigrationManager(getKinContext(), "nitz"/*AuthRepository.getInstance().getAppID()*/);
 
 		try {
 			checkInstanceNotNull();

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -202,7 +202,6 @@ public class Kin {
 	}
 
 	private static void internalLogin(@NonNull final String jwt, final KinCallback<Void> loginCallback) {
-		MigrationManager migrationManager = createMigrationManager(getKinContext(), AuthRepository.getInstance().getAppID());
 
 		try {
 			checkInstanceNotNull();
@@ -219,6 +218,7 @@ public class Kin {
 			}
 
 			AuthRepository.getInstance().setJWT(jwt);
+			MigrationManager migrationManager = createMigrationManager(getKinContext(), AuthRepository.getInstance().getAppID());
 			BlockchainSourceImpl.getInstance().setMigrationManager(migrationManager);
 			BlockchainSourceImpl.getInstance().startMigrationProcess(new MigrationProcessListener() {
 				@Override

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -271,24 +271,8 @@ public class Kin {
 			});*/
 
 		} catch (final ClientException exception) {
-			if (exception.getCode() == ClientException.BLOCKCHAIN_ENDPOINT_CHANGED) {
-				BlockchainSourceImpl.getInstance().startMigrationProcess(new MigrationProcessListener() {
-					@Override
-					public void onMigrationStart() {}
-
-					@Override
-					public void onMigrationEnd() {
-						internalLogin(jwt, loginCallback);
-					}
-
-					@Override
-					public void onMigrationError(BlockchainException error) {
-						sendLoginFailed(error, loginCallback);
-					}
-				});
-			} else {
-				sendLoginFailed(exception, loginCallback);
-			}
+			// TODO: handle migration error here
+			sendLoginFailed(exception, loginCallback);
 		}
 	}
 

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -40,8 +40,11 @@ import com.kin.ecosystem.core.data.auth.AuthLocalData;
 import com.kin.ecosystem.core.data.auth.AuthRemoteData;
 import com.kin.ecosystem.core.data.auth.AuthRepository;
 import com.kin.ecosystem.core.data.auth.UserLoginState;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource.MigrationProcessListener;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSourceImpl;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSourceLocal;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSourceRemote;
 import com.kin.ecosystem.core.data.internal.ConfigurationImpl;
 import com.kin.ecosystem.core.data.offer.OfferRemoteData;
 import com.kin.ecosystem.core.data.offer.OfferRepository;
@@ -197,6 +200,8 @@ public class Kin {
 	}
 
 	private static void internalLogin(@NonNull final String jwt, final KinCallback<Void> loginCallback) {
+		MigrationManager migrationManager = createMigrationManager(getKinContext(), AuthRepository.getInstance().getAppID());
+
 		try {
 			checkInstanceNotNull();
 			@UserLoginState final int loginState = AuthRepository.getInstance().getUserLoginState(jwt);
@@ -209,12 +214,10 @@ public class Kin {
 					break;
 				case UserLoginState.SAME_USER:
 					break;
-
 			}
 
 			AuthRepository.getInstance().setJWT(jwt);
-			BlockchainSourceImpl.getInstance().setMigrationManager(getMigrationManager(
-				getKinContext(), AuthRepository.getInstance().getAppID()));
+			BlockchainSourceImpl.getInstance().setMigrationManager(migrationManager);
 			AuthRepository.getInstance().getAccountInfo(new KinCallback<AccountInfo>() {
 				@Override
 				public void onResponse(AccountInfo accountInfo) {
@@ -252,7 +255,24 @@ public class Kin {
 			});
 
 		} catch (final ClientException exception) {
-			sendLoginFailed(exception, loginCallback);
+			if (exception.getCode() == ClientException.BLOCKCHAIN_ENDPOINT_CHANGED) {
+				BlockchainSourceImpl.getInstance().startMigrationProcess(new MigrationProcessListener() {
+					@Override
+					public void onMigrationStart() {}
+
+					@Override
+					public void onMigrationEnd() {
+						internalLogin(jwt, loginCallback);
+					}
+
+					@Override
+					public void onMigrationError(BlockchainException error) {
+						sendLoginFailed(error, loginCallback);
+					}
+				});
+			} else {
+				sendLoginFailed(exception, loginCallback);
+			}
 		}
 	}
 
@@ -299,7 +319,7 @@ public class Kin {
 		});
 	}
 
-	private static MigrationManager getMigrationManager(Context context,@NonNull String appId) {
+	private static MigrationManager createMigrationManager(Context context,@NonNull String appId) {
 		KinEnvironment kinEnvironment = ConfigurationImpl.getInstance().getEnvironment();
 
 		final String oldNetworkUrl = kinEnvironment.getOldBlockchainNetworkUrl();
@@ -314,8 +334,10 @@ public class Kin {
 		MigrationNetworkInfo migrationNetworkInfo = new MigrationNetworkInfo(oldNetworkUrl, oldNetworkId,
 			newNetworkUrl, newNetworkId, issuer, migrationServiceUrl);
 
+		final BlockchainSource.Local local = BlockchainSourceLocal.getInstance(context);
+		final BlockchainSource.Remote remote = BlockchainSourceRemote.getInstance(getInstance(context).executorsUtil);
 		MigrationManager migrationManager = new MigrationManager(context, appId, migrationNetworkInfo,
-			new KinBlockchainVersionProvider(appId),
+			new KinBlockchainVersionProvider(local, remote),
 			new MigrationEventsListener(EventLoggerImpl.getInstance()), KIN_ECOSYSTEM_STORE_PREFIX_KEY);
 		migrationManager.enableLogs(Logger.isEnabled());
 		return migrationManager;

--- a/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
+++ b/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
@@ -1,5 +1,7 @@
 package com.kin.ecosystem;
 
+import com.kin.ecosystem.core.Log;
+import com.kin.ecosystem.core.Logger;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.network.ApiException;
 import kin.sdk.migration.common.KinSdkVersion;
@@ -18,6 +20,7 @@ class KinBlockchainVersionProvider implements IKinVersionProvider {
 	@Override
 	public KinSdkVersion getKinSdkVersion() throws FailedToResolveSdkVersionException {
 		if (local.getBlockchainVersion() == KinSdkVersion.NEW_KIN_SDK) {
+			Logger.log(new Log().withTag("MOO").text("new version"));
 			return KinSdkVersion.NEW_KIN_SDK;
 		}
 
@@ -29,6 +32,7 @@ class KinBlockchainVersionProvider implements IKinVersionProvider {
 		}
 
 		local.setBlockchainVersion(version);
+		Logger.log(new Log().withTag("MOO").text("version: " + version));
 
 		return version;
 	}

--- a/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
+++ b/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
@@ -7,8 +7,8 @@ import kin.sdk.migration.common.exception.FailedToResolveSdkVersionException;
 import kin.sdk.migration.common.interfaces.IKinVersionProvider;
 
 class KinBlockchainVersionProvider implements IKinVersionProvider {
-	private BlockchainSource.Local local;
-	private BlockchainSource.Remote remote;
+	private final BlockchainSource.Local local;
+	private final BlockchainSource.Remote remote;
 
 	public KinBlockchainVersionProvider(BlockchainSource.Local local, BlockchainSource.Remote remote) {
 		this.local = local;

--- a/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
+++ b/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
@@ -1,16 +1,35 @@
 package com.kin.ecosystem;
 
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
+import com.kin.ecosystem.core.network.ApiException;
 import kin.sdk.migration.common.KinSdkVersion;
 import kin.sdk.migration.common.exception.FailedToResolveSdkVersionException;
 import kin.sdk.migration.common.interfaces.IKinVersionProvider;
 
 class KinBlockchainVersionProvider implements IKinVersionProvider {
+	private BlockchainSource.Local local;
+	private BlockchainSource.Remote remote;
 
-	public KinBlockchainVersionProvider(String appId) {
+	public KinBlockchainVersionProvider(BlockchainSource.Local local, BlockchainSource.Remote remote) {
+		this.local = local;
+		this.remote = remote;
 	}
 
 	@Override
 	public KinSdkVersion getKinSdkVersion() throws FailedToResolveSdkVersionException {
-		return KinSdkVersion.OLD_KIN_SDK;
+		if (local.getBlockchainVersion() == KinSdkVersion.NEW_KIN_SDK) {
+			return KinSdkVersion.NEW_KIN_SDK;
+		}
+
+		KinSdkVersion version;
+		try {
+			version = remote.getBlockchainVersion();
+		} catch (ApiException e) {
+			throw new FailedToResolveSdkVersionException();
+		}
+
+		local.setBlockchainVersion(version);
+
+		return version;
 	}
 }

--- a/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
+++ b/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
@@ -1,7 +1,5 @@
 package com.kin.ecosystem;
 
-import com.kin.ecosystem.core.Log;
-import com.kin.ecosystem.core.Logger;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.network.ApiException;
 import kin.sdk.migration.common.KinSdkVersion;
@@ -20,7 +18,6 @@ class KinBlockchainVersionProvider implements IKinVersionProvider {
 	@Override
 	public KinSdkVersion getKinSdkVersion() throws FailedToResolveSdkVersionException {
 		if (local.getBlockchainVersion() == KinSdkVersion.NEW_KIN_SDK) {
-			Logger.log(new Log().withTag("MOO").text("new version"));
 			return KinSdkVersion.NEW_KIN_SDK;
 		}
 
@@ -32,7 +29,6 @@ class KinBlockchainVersionProvider implements IKinVersionProvider {
 		}
 
 		local.setBlockchainVersion(version);
-		Logger.log(new Log().withTag("MOO").text("version: " + version));
 
 		return version;
 	}

--- a/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
@@ -152,10 +152,10 @@ public class PollWebViewPresenter extends BasePresenter<IPollWebView> implements
 			isOrderSubmitted = true;
 			final String orderId = openOrder.getId();
 			eventLogger.send(EarnOrderCompletionSubmitted.create(offerID, orderId));
-			orderRepository.submitOrder(offerID, result, orderId, new KinCallback<Order>() {
+			orderRepository.submitEarnOrder(offerID, result, orderId, new KinCallback<Order>() {
 				@Override
 				public void onResponse(Order response) {
-
+					// TODO: shouldn't something happen here?
 				}
 
 				@Override

--- a/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
+++ b/sdk/src/main/java/com/kin/ecosystem/poll/presenter/PollWebViewPresenter.java
@@ -154,9 +154,7 @@ public class PollWebViewPresenter extends BasePresenter<IPollWebView> implements
 			eventLogger.send(EarnOrderCompletionSubmitted.create(offerID, orderId));
 			orderRepository.submitEarnOrder(offerID, result, orderId, new KinCallback<Order>() {
 				@Override
-				public void onResponse(Order response) {
-					// TODO: shouldn't something happen here?
-				}
+				public void onResponse(Order response) {}
 
 				@Override
 				public void onFailure(KinEcosystemException exception) {

--- a/sdk/src/main/java/com/kin/ecosystem/recovery/BackupAndRestoreImpl.java
+++ b/sdk/src/main/java/com/kin/ecosystem/recovery/BackupAndRestoreImpl.java
@@ -23,7 +23,8 @@ import com.kin.ecosystem.recovery.exception.BackupRestoreErrorUtil;
 
 public class BackupAndRestoreImpl implements BackupAndRestore {
 
-	protected final BackupManager backupManager;
+	private final Activity activity;
+	protected BackupManager backupManager;
 	private final AccountManager accountManager;
 	private final EventLogger eventLogger;
 	private final SettingsDataSource settingsDataSource;
@@ -32,8 +33,9 @@ public class BackupAndRestoreImpl implements BackupAndRestore {
 	public BackupAndRestoreImpl(@NonNull final Activity activity, @NonNull AccountManager accountManager,
 		@NonNull EventLogger eventLogger, @NonNull BlockchainSource blockchainSource,
 		SettingsDataSource settingsDataSource) {
+		this.activity = activity;
 		this.blockchainSource = blockchainSource;
-		this.backupManager = new BackupManager(activity, blockchainSource.getKeyStoreProvider());
+		this.backupManager = getNewBackupManager();
 		this.accountManager = accountManager;
 		this.eventLogger = eventLogger;
 		this.settingsDataSource = settingsDataSource;
@@ -90,21 +92,6 @@ public class BackupAndRestoreImpl implements BackupAndRestore {
 		});
 	}
 
-	private void switchAccount(int accountIndex, @NonNull final BackupAndRestoreCallback backupCallback) {
-		accountManager.switchAccount(accountIndex, new KinCallback<Boolean>() {
-			@Override
-			public void onResponse(Boolean response) {
-				eventLogger.send(RestoreWalletCompleted.create());
-				backupCallback.onSuccess();
-			}
-
-			@Override
-			public void onFailure(KinEcosystemException exception) {
-				backupCallback.onFailure(new BackupAndRestoreException(RESTORE_SWITCH_ACCOUNT_FAILED,
-					exception != null ? exception.getMessage() : "Switch account failed", exception));
-			}
-		});
-	}
 
 	@Override
 	public void registerRestoreCallback(@NonNull final BackupAndRestoreCallback restoreCallback) {
@@ -123,6 +110,28 @@ public class BackupAndRestoreImpl implements BackupAndRestore {
 			@Override
 			public void onFailure(BackupException exception) {
 				restoreCallback.onFailure(BackupRestoreErrorUtil.get(exception));
+			}
+		});
+	}
+
+	private BackupManager getNewBackupManager() {
+		return new BackupManager(activity, blockchainSource.getKeyStoreProvider());
+	}
+
+	private void switchAccount(int accountIndex, @NonNull final BackupAndRestoreCallback backupCallback) {
+		accountManager.switchAccount(accountIndex, new KinCallback<Boolean>() {
+			@Override
+			public void onResponse(Boolean response) {
+				release();
+				backupManager = getNewBackupManager(); //update the backupManager
+				eventLogger.send(RestoreWalletCompleted.create());
+				backupCallback.onSuccess();
+			}
+
+			@Override
+			public void onFailure(KinEcosystemException exception) {
+				backupCallback.onFailure(new BackupAndRestoreException(RESTORE_SWITCH_ACCOUNT_FAILED,
+					exception != null ? exception.getMessage() : "Switch account failed", exception));
 			}
 		});
 	}

--- a/sdk/src/main/java/com/kin/ecosystem/recovery/BackupAndRestoreImpl.java
+++ b/sdk/src/main/java/com/kin/ecosystem/recovery/BackupAndRestoreImpl.java
@@ -23,6 +23,8 @@ import com.kin.ecosystem.recovery.exception.BackupRestoreErrorUtil;
 
 public class BackupAndRestoreImpl implements BackupAndRestore {
 
+	private static final String SWITCH_ACCOUNT_FAILED = "Switch account failed";
+
 	private final Activity activity;
 	protected BackupManager backupManager;
 	private final AccountManager accountManager;
@@ -131,7 +133,7 @@ public class BackupAndRestoreImpl implements BackupAndRestore {
 			@Override
 			public void onFailure(KinEcosystemException exception) {
 				backupCallback.onFailure(new BackupAndRestoreException(RESTORE_SWITCH_ACCOUNT_FAILED,
-					exception != null ? exception.getMessage() : "Switch account failed", exception));
+					exception != null ? exception.getMessage() : SWITCH_ACCOUNT_FAILED, exception));
 			}
 		});
 	}


### PR DESCRIPTION
the login process should now start the migration flow.
also, the way in which the sdk sends orders/transactions has been changed for when the client is in kin3,
so that the signed transaction is sent to the server which will then submit it to the BC.
also, in both (kin2/kin3) the sdk won't poll on the BC to get the order status, but will poll on the server
