### PR TITLE
fix moving quickly between earn and used tabs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-SAMPLE_VERSION_NAME=0.1.4
+SAMPLE_VERSION_NAME=0.1.5
 
 KIN_ECOSYSTEM_SDK_VERSION_NAME=1.0.1
 

--- a/sdk/src/main/java/com/kin/ecosystem/widget/KinEcosystemTabs.kt
+++ b/sdk/src/main/java/com/kin/ecosystem/widget/KinEcosystemTabs.kt
@@ -97,10 +97,6 @@ class KinEcosystemTabs @JvmOverloads constructor(context: Context,
     private fun setSelectedTab(selectedTabIndex: Tab, animate: Boolean = true) {
         if (currentSelectedTab == selectedTabIndex) return
 
-        if (currentSelectedTab != null) {
-            onTabClickedListener?.onTabClicked(selectedTabIndex)
-        }
-        currentSelectedTab = selectedTabIndex
         if (animate) {
 
             if (isAnimating) return
@@ -237,6 +233,11 @@ class KinEcosystemTabs @JvmOverloads constructor(context: Context,
                 leftTab.setTextColor(textDeselectedColor)
             }
         }
+
+        if (currentSelectedTab != null) {
+            onTabClickedListener?.onTabClicked(selectedTabIndex)
+        }
+        currentSelectedTab = selectedTabIndex
     }
 
     fun setOnTabClickedListener(listener: (Tab) -> Unit) {


### PR DESCRIPTION
#### Main purpose:
The displayed tab was wrong, on quick movements between earn and used tabs
#### Technical description:
- moving selected tab listener invocation after `isAnimating` check.