### PR TITLE
move setTheme to EcosystemBaseActivity

### DIFF
--- a/sdk/src/main/java/com/kin/ecosystem/base/KinEcosystemBaseActivity.kt
+++ b/sdk/src/main/java/com/kin/ecosystem/base/KinEcosystemBaseActivity.kt
@@ -4,7 +4,11 @@ import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.support.annotation.LayoutRes
+import android.support.annotation.StyleRes
 import android.support.v7.app.AppCompatActivity
+import com.kin.ecosystem.R
+import com.kin.ecosystem.common.KinTheme
+import com.kin.ecosystem.core.data.internal.ConfigurationImpl
 
 abstract class KinEcosystemBaseActivity : AppCompatActivity() {
 
@@ -15,11 +19,22 @@ abstract class KinEcosystemBaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        KinEcosystemInitiator.init(applicationContext)
+        setTheme(getKinTheme())
         setContentView(layoutRes)
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
-        KinEcosystemInitiator.init(applicationContext)
         initViews()
+    }
+
+    @StyleRes
+    private fun getKinTheme(): Int {
+        return ConfigurationImpl.getInstance().kinTheme?.let {
+            when (it) {
+                KinTheme.LIGHT -> R.style.KinecosysNoActionBar_Light
+                KinTheme.DARK -> R.style.KinecosysNoActionBar_Dark
+            }
+        } ?: R.style.KinecosysNoActionBar_Light
     }
 }

--- a/sdk/src/main/java/com/kin/ecosystem/main/view/EcosystemActivity.kt
+++ b/sdk/src/main/java/com/kin/ecosystem/main/view/EcosystemActivity.kt
@@ -6,21 +6,16 @@ import android.animation.ValueAnimator
 import android.content.Intent
 import android.os.Bundle
 import android.support.annotation.IdRes
-import android.support.annotation.StyleRes
 import android.support.constraint.ConstraintLayout
 import android.support.v4.app.Fragment
-import android.widget.Toast
 import com.kin.ecosystem.R
 import com.kin.ecosystem.base.AnimConsts
 import com.kin.ecosystem.base.CustomAnimation
 import com.kin.ecosystem.base.KinEcosystemBaseActivity
 import com.kin.ecosystem.base.customAnimation
-import com.kin.ecosystem.common.KinTheme.DARK
-import com.kin.ecosystem.common.KinTheme.LIGHT
 import com.kin.ecosystem.core.bi.EventLoggerImpl
 import com.kin.ecosystem.core.data.auth.AuthRepository
 import com.kin.ecosystem.core.data.blockchain.BlockchainSourceImpl
-import com.kin.ecosystem.core.data.internal.ConfigurationImpl
 import com.kin.ecosystem.core.data.settings.SettingsDataSourceImpl
 import com.kin.ecosystem.core.data.settings.SettingsDataSourceLocal
 import com.kin.ecosystem.core.util.DeviceUtils
@@ -56,7 +51,6 @@ class EcosystemActivity : KinEcosystemBaseActivity(), IEcosystemView {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        setTheme(getKinTheme())
         super.onCreate(savedInstanceState)
         initViews()
         ecosystemPresenter = EcosystemPresenter(AuthRepository.getInstance(),
@@ -65,16 +59,6 @@ class EcosystemActivity : KinEcosystemBaseActivity(), IEcosystemView {
                 EventLoggerImpl.getInstance(),
                 this, savedInstanceState, intent.extras)
         ecosystemPresenter?.onAttach(this@EcosystemActivity)
-    }
-
-    @StyleRes
-    private fun getKinTheme(): Int {
-        return ConfigurationImpl.getInstance().kinTheme?.let {
-            when (it) {
-                LIGHT -> R.style.KinecosysNoActionBar_Light
-                DARK -> R.style.KinecosysNoActionBar_Dark
-            }
-        } ?: R.style.KinecosysNoActionBar_Light
     }
 
     override fun initViews() {


### PR DESCRIPTION
#### Main purpose:
- Application crashed while application restart by the OS.
- Solves #304
#### Technical description:
- Moved up `KinEcosystemInitiator` to it will be triggered before getting the Theme
- Moved setThem to `EcosystemBaseActivity` after `super.onCreate` and before `etContentView`
