### PR TITLE
fix blank errors while login, native spend and earn

### DIFF
--- a/common/src/main/java/com/kin/ecosystem/common/exception/BlockchainException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/BlockchainException.java
@@ -21,6 +21,7 @@ public class BlockchainException extends KinEcosystemException {
 	public static final int TRANSACTION_FAILED = 6005;
 	public static final int ACCOUNT_LOADING_FAILED = 6006;
 	public static final int MIGRATION_FAILED = 6007;
+	public static final int SIGN_TRANSACTION_FAILED = 6008;
 
 	public BlockchainException(@BlockchainErrorCodes int code, String message, Throwable cause) {
 		super(code, message, cause);

--- a/common/src/main/java/com/kin/ecosystem/common/exception/KinEcosystemException.java
+++ b/common/src/main/java/com/kin/ecosystem/common/exception/KinEcosystemException.java
@@ -8,7 +8,7 @@ public class KinEcosystemException extends Exception {
 
 	private int code;
 
-	public KinEcosystemException(@NonNull int code, @NonNull String message, @NonNull Throwable cause) {
+	public KinEcosystemException(int code, @NonNull String message, @NonNull Throwable cause) {
 		super(message, cause);
 		this.code = code;
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManager.java
+++ b/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManager.java
@@ -2,6 +2,7 @@ package com.kin.ecosystem.core.accountmanager;
 
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.Observer;
 import com.kin.ecosystem.common.exception.KinEcosystemException;
@@ -45,6 +46,7 @@ public interface AccountManager {
 
 	void removeAccountStateObserver(@NonNull final Observer<Integer> observer);
 
+	@Nullable
 	KinEcosystemException getError();
 
 	interface Local {

--- a/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManagerImpl.java
+++ b/core/src/main/java/com/kin/ecosystem/core/accountmanager/AccountManagerImpl.java
@@ -1,6 +1,7 @@
 package com.kin.ecosystem.core.accountmanager;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import com.kin.ecosystem.common.Callback;
 import com.kin.ecosystem.common.KinCallback;
 import com.kin.ecosystem.common.ObservableData;
@@ -89,6 +90,7 @@ public class AccountManagerImpl implements AccountManager {
 	}
 
 	@Override
+	@Nullable
 	public KinEcosystemException getError() {
 		return error;
 	}
@@ -186,7 +188,7 @@ public class AccountManagerImpl implements AccountManager {
 
 	private void updateWalletAddressProcess(final String address, final int accountIndex,
 		final KinCallback<Boolean> callback) {
-		blockchainSource.getMigrationInfo(address, new Callback<MigrationInfo, ApiException>() {
+		blockchainSource.getMigrationInfo(address, new KinCallback<MigrationInfo>() {
 			@Override
 			public void onResponse(MigrationInfo migrationInfo) {
 				boolean isRestorable = migrationInfo.isRestorable();
@@ -194,17 +196,15 @@ public class AccountManagerImpl implements AccountManager {
 				if (isRestorable) {
 					startMigrationProcess(migrationInfo, address, accountIndex, callback);
 				} else {
-					// TODO: 02/04/2019 is there another normal to send that error to onFailure?
-					onFailure(new ApiException(ServiceException.WALLET_WAS_NOT_CREATED_IN_THIS_APP,
-						ErrorUtil.createWalletWasNotCreatedInThisAppException()));
+					onFailure(ErrorUtil.createWalletWasNotCreatedInThisAppException());
 				}
 			}
 
 			@Override
-			public void onFailure(ApiException exception) {
+			public void onFailure(KinEcosystemException exception) {
 				Logger.log(new Log().priority(Log.ERROR).withTag(TAG).text("getMigrationInfo: onFailure"));
 				deleteRestoredAccount(accountIndex);
-				callback.onFailure(ErrorUtil.fromApiException(exception));
+				callback.onFailure(exception);
 			}
 		});
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSource.java
@@ -25,7 +25,7 @@ public interface BlockchainSource {
 	 * @param publicAddress the address associated with the migration information.
 	 * @param callback a callback for this method call.
 	 */
-	void getMigrationInfo(String publicAddress, Callback<MigrationInfo, ApiException> callback);
+	void getMigrationInfo(String publicAddress, KinCallback<MigrationInfo> callback);
 
 	/**
 	 * Set the migration manager
@@ -42,13 +42,6 @@ public interface BlockchainSource {
 	 * @param listener
 	 */
 	void startMigrationProcess(final MigrationProcessListener listener);
-
-	/**
-	 * Starts the migration process using the migration module for a specific public address
-	 * @param publicAddress
-	 * @param listener
-	 */
-	void startMigrationProcess(final String publicAddress, final MigrationProcessListener listener);
 
 	/**
 	 * Starts the migration process using the migration module for a specific public address and with a migration info object.
@@ -212,8 +205,6 @@ public interface BlockchainSource {
 		KinSdkVersion getBlockchainVersion() throws ApiException; // synced and blocking
 
 		void getBlockchainVersion(@NonNull final Callback<KinSdkVersion, ApiException> callback);
-
-		MigrationInfo getMigrationInfo(String publicAddress)  throws ApiException; // synced and blocking
 
 		void getMigrationInfo(String publicAddress, @NonNull final Callback<MigrationInfo, ApiException> callback);
 

--- a/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/blockchain/BlockchainSourceRemote.java
@@ -141,18 +141,6 @@ public class BlockchainSourceRemote implements Remote {
 	}
 
 	@Override
-	public MigrationInfo getMigrationInfo(@NonNull String publicAddress) throws ApiException {
-		try {
-			final MigrationInfo info = migrationApi.getMigrationInfoSync(publicAddress);
-			sendMigrationInfoSuccessEvent(publicAddress, info);
-			return info;
-		} catch (ApiException e) {
-			eventLogger.send(MigrationStatusCheckFailed.create(getPublicAddress(), getErrorMessage(e)));
-			throw e;
-		}
-	}
-
-	@Override
 	public void getMigrationInfo(final String publicAddress, final @NonNull Callback<MigrationInfo, ApiException> callback) {
 		try {
 			migrationApi.getMigrationInfoAsync(publicAddress, new ApiCallback<MigrationInfo>() {

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
@@ -10,6 +10,7 @@ import com.kin.ecosystem.core.bi.events.EarnOrderCreationReceived;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
 import com.kin.ecosystem.core.network.model.Offer.OfferType;
 import com.kin.ecosystem.core.network.model.Order;
+import com.kin.ecosystem.core.util.StringUtil;
 import java.math.BigDecimal;
 
 class ExternalEarnOrderCall extends CreateExternalOrderCall {
@@ -26,17 +27,22 @@ class ExternalEarnOrderCall extends CreateExternalOrderCall {
 	@Override
 	void sendOrderCreationFailedEvent(String offerId, KinEcosystemException exception) {
 		final String reason = exception.getMessage();
-		eventLogger.send(EarnOrderCreationFailed.create(reason, offerId, EarnOrderCreationFailed.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		eventLogger.send(EarnOrderCreationFailed.create(reason, finalOfferId, EarnOrderCreationFailed.Origin.EXTERNAL));
 	}
 
 	@Override
 	void sendOrderCreationReceivedEvent(String offerId, String orderId) {
-		eventLogger.send(EarnOrderCreationReceived.create(offerId, orderId, EarnOrderCreationReceived.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+		eventLogger.send(EarnOrderCreationReceived.create(finalOfferId, finalOrderId, EarnOrderCreationReceived.Origin.EXTERNAL));
 	}
 
 	@Override
 	void sendCompletionSubmittedEvent(String offerId, String orderId) {
-		eventLogger.send(EarnOrderCompletionSubmitted.create(offerId, orderId, EarnOrderCompletionSubmitted.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+		eventLogger.send(EarnOrderCompletionSubmitted.create(finalOfferId, finalOrderId, EarnOrderCompletionSubmitted.Origin.EXTERNAL));
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalEarnOrderCall.java
@@ -1,17 +1,70 @@
 package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
+import com.kin.ecosystem.common.KinCallback;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.core.bi.EventLogger;
+import com.kin.ecosystem.core.bi.events.EarnOrderCompletionSubmitted;
+import com.kin.ecosystem.core.bi.events.EarnOrderCreationFailed;
+import com.kin.ecosystem.core.bi.events.EarnOrderCreationReceived;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
+import com.kin.ecosystem.core.network.model.Offer.OfferType;
+import com.kin.ecosystem.core.network.model.Order;
+import java.math.BigDecimal;
 
 class ExternalEarnOrderCall extends CreateExternalOrderCall {
 
-    ExternalEarnOrderCall(
-        @NonNull OrderDataSource orderRepository,
-        @NonNull BlockchainSource blockchainSource,
-        @NonNull String orderJwt,
-        @NonNull EventLogger eventLogger,
-        @NonNull ExternalOrderCallbacks externalEarnOrderCallbacks) {
-        super(orderRepository, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks);
-    }
+	ExternalEarnOrderCall(
+		@NonNull OrderDataSource orderRepository,
+		@NonNull BlockchainSource blockchainSource,
+		@NonNull String orderJwt,
+		@NonNull EventLogger eventLogger,
+		@NonNull ExternalOrderCallbacks externalEarnOrderCallbacks) {
+		super(orderRepository, blockchainSource, orderJwt, eventLogger, externalEarnOrderCallbacks);
+	}
+
+	@Override
+	void sendOrderCreationFailedEvent(String offerId, KinEcosystemException exception) {
+		final String reason = exception.getMessage();
+		eventLogger.send(EarnOrderCreationFailed.create(reason, offerId, EarnOrderCreationFailed.Origin.EXTERNAL));
+	}
+
+	@Override
+	void sendOrderCreationReceivedEvent(String offerId, String orderId) {
+		eventLogger.send(EarnOrderCreationReceived.create(offerId, orderId, EarnOrderCreationReceived.Origin.EXTERNAL));
+	}
+
+	@Override
+	void sendCompletionSubmittedEvent(String offerId, String orderId) {
+		eventLogger.send(EarnOrderCompletionSubmitted.create(offerId, orderId, EarnOrderCompletionSubmitted.Origin.EXTERNAL));
+	}
+
+	@Override
+	OfferType getOfferType() {
+		return OfferType.EARN;
+	}
+
+	@Override
+	void sendKin2Order(final String orderId, final String offerId, final String address, final BigDecimal amount) {
+		submitOrder(offerId, orderId);
+	}
+
+	@Override
+	void sendKin3Order(String orderId, String offerId, String address, BigDecimal amount) {
+		submitOrder(offerId, orderId);
+	}
+
+	private void submitOrder(final String offerId, final String orderId) {
+		orderRepository.submitEarnOrder(offerId, null, orderId, new KinCallback<Order>() {
+			@Override
+			public void onResponse(Order order) {
+				onSubmissionSucceed(order.getOrderId());
+			}
+
+			@Override
+			public void onFailure(KinEcosystemException e) {
+				onSubmissionFailed(offerId, orderId, e);
+			}
+		});
+	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
@@ -13,6 +13,7 @@ import com.kin.ecosystem.core.data.blockchain.BlockchainSource.SignTransactionLi
 import com.kin.ecosystem.core.network.model.Offer.OfferType;
 import com.kin.ecosystem.core.network.model.Order;
 import com.kin.ecosystem.core.util.ErrorUtil;
+import com.kin.ecosystem.core.util.StringUtil;
 import java.math.BigDecimal;
 import kin.sdk.migration.common.exception.OperationFailedException;
 
@@ -30,17 +31,22 @@ class ExternalSpendOrderCall extends CreateExternalOrderCall {
 	@Override
 	void sendOrderCreationFailedEvent(String offerId, KinEcosystemException exception) {
 		final String reason = exception.getMessage();
-		eventLogger.send(SpendOrderCreationFailed.create(reason, offerId, true, SpendOrderCreationFailed.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		eventLogger.send(SpendOrderCreationFailed.create(reason, finalOfferId, true, SpendOrderCreationFailed.Origin.EXTERNAL));
 	}
 
 	@Override
 	void sendOrderCreationReceivedEvent(String offerId, String orderId) {
-		eventLogger.send(SpendOrderCreationReceived.create(offerId, orderId, true, SpendOrderCreationReceived.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+		eventLogger.send(SpendOrderCreationReceived.create(finalOfferId, finalOrderId, true, SpendOrderCreationReceived.Origin.EXTERNAL));
 	}
 
 	@Override
 	void sendCompletionSubmittedEvent(String offerId, String orderId) {
-		eventLogger.send(SpendOrderCompletionSubmitted.create(offerId, orderId, true, SpendOrderCompletionSubmitted.Origin.EXTERNAL));
+		final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+		final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+		eventLogger.send(SpendOrderCompletionSubmitted.create(finalOfferId, finalOrderId, true, SpendOrderCompletionSubmitted.Origin.EXTERNAL));
 	}
 
 	@Override

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/ExternalSpendOrderCall.java
@@ -1,8 +1,20 @@
 package com.kin.ecosystem.core.data.order;
 
 import android.support.annotation.NonNull;
+import com.kin.ecosystem.common.KinCallback;
+import com.kin.ecosystem.common.exception.BlockchainException;
+import com.kin.ecosystem.common.exception.KinEcosystemException;
 import com.kin.ecosystem.core.bi.EventLogger;
+import com.kin.ecosystem.core.bi.events.SpendOrderCompletionSubmitted;
+import com.kin.ecosystem.core.bi.events.SpendOrderCreationFailed;
+import com.kin.ecosystem.core.bi.events.SpendOrderCreationReceived;
 import com.kin.ecosystem.core.data.blockchain.BlockchainSource;
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource.SignTransactionListener;
+import com.kin.ecosystem.core.network.model.Offer.OfferType;
+import com.kin.ecosystem.core.network.model.Order;
+import com.kin.ecosystem.core.util.ErrorUtil;
+import java.math.BigDecimal;
+import kin.sdk.migration.common.exception.OperationFailedException;
 
 class ExternalSpendOrderCall extends CreateExternalOrderCall {
 
@@ -13,5 +25,68 @@ class ExternalSpendOrderCall extends CreateExternalOrderCall {
 		@NonNull EventLogger eventLogger,
 		@NonNull ExternalSpendOrderCallbacks externalSpendOrderCallbacks) {
 		super(orderRepository, blockchainSource, orderJwt, eventLogger, externalSpendOrderCallbacks);
+	}
+
+	@Override
+	void sendOrderCreationFailedEvent(String offerId, KinEcosystemException exception) {
+		final String reason = exception.getMessage();
+		eventLogger.send(SpendOrderCreationFailed.create(reason, offerId, true, SpendOrderCreationFailed.Origin.EXTERNAL));
+	}
+
+	@Override
+	void sendOrderCreationReceivedEvent(String offerId, String orderId) {
+		eventLogger.send(SpendOrderCreationReceived.create(offerId, orderId, true, SpendOrderCreationReceived.Origin.EXTERNAL));
+	}
+
+	@Override
+	void sendCompletionSubmittedEvent(String offerId, String orderId) {
+		eventLogger.send(SpendOrderCompletionSubmitted.create(offerId, orderId, true, SpendOrderCompletionSubmitted.Origin.EXTERNAL));
+	}
+
+	@Override
+	OfferType getOfferType() {
+		return OfferType.SPEND;
+	}
+
+	@Override
+	void sendKin2Order(final String orderId, final String offerId, final String address, final BigDecimal amount) {
+		orderRepository.submitSpendOrder(offerId, null, orderId, new KinCallback<Order>() {
+			@Override
+			public void onResponse(Order order) {
+				blockchainSource.sendTransaction(address, amount, orderId, offerId);
+				onSubmissionSucceed(order.getOrderId());
+			}
+
+			@Override
+			public void onFailure(KinEcosystemException exception) {
+				onSubmissionFailed(offerId, orderId, exception);
+			}
+		});
+	}
+
+	@Override
+	void sendKin3Order(final String orderId,final  String offerId, final String address, final  BigDecimal amount) {
+		try {
+			blockchainSource.signTransaction(address, amount, orderId, offerId, new SignTransactionListener() {
+				@Override
+				public void onTransactionSigned(@NonNull String transaction) {
+					orderRepository.submitSpendOrder(offerId, transaction, orderId, new KinCallback<Order>() {
+						@Override
+						public void onResponse(Order order) {
+							onSubmissionSucceed(order.getOrderId());
+						}
+
+						@Override
+						public void onFailure(KinEcosystemException exception) {
+							onSubmissionFailed(offerId, orderId, exception);
+						}
+					});
+				}
+			});
+		} catch (OperationFailedException e) {
+			final KinEcosystemException exception = new KinEcosystemException(BlockchainException.SIGN_TRANSACTION_FAILED,
+				ErrorUtil.getMessage(e, "Sign Transaction Failed"), e);
+			onSubmissionFailed(offerId, orderId, exception);
+		}
 	}
 }

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OfferJwtBody.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OfferJwtBody.java
@@ -1,0 +1,22 @@
+package com.kin.ecosystem.core.data.order;
+
+import com.kin.ecosystem.core.network.model.Offer.OfferType;
+
+public class OfferJwtBody {
+
+	private String offerId;
+	private OfferType type;
+
+	public OfferJwtBody(String offerId, OfferType type) {
+		this.offerId = offerId;
+		this.type = type;
+	}
+
+	public String getOfferId() {
+		return offerId;
+	}
+
+	public OfferType getType() {
+		return type;
+	}
+}

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
@@ -374,8 +374,9 @@ public class OrderRepository implements OrderDataSource {
 				}
 
 				private void handleOnFailure(final String offerId, final String orderId, KinEcosystemException exception) {
-					eventLogger.send(SpendOrderFailed
-						.create(exception.getMessage(), offerId, orderId, true, SpendOrderFailed.Origin.EXTERNAL));
+					final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+					final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+					eventLogger.send(SpendOrderFailed.create(exception.getMessage(), finalOfferId, finalOrderId, true, SpendOrderFailed.Origin.EXTERNAL));
 
 					if (callback != null) {
 						callback.onFailure(exception);
@@ -433,7 +434,9 @@ public class OrderRepository implements OrderDataSource {
 				if (callback != null) {
 					callback.onFailure(exception);
 				}
-				eventLogger.send(EarnOrderFailed.create(exception.getMessage(), offerId, orderId, EarnOrderFailed.Origin.EXTERNAL));
+				final String finalOfferId = StringUtil.safeGuardNullString(offerId);
+				final String finalOrderId = StringUtil.safeGuardNullString(orderId);
+				eventLogger.send(EarnOrderFailed.create(exception.getMessage(), finalOfferId, finalOrderId, EarnOrderFailed.Origin.EXTERNAL));
 			}
 		}).start();
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/order/OrderRepository.java
@@ -37,6 +37,7 @@ import com.kin.ecosystem.core.network.model.Order.Origin;
 import com.kin.ecosystem.core.network.model.Order.Status;
 import com.kin.ecosystem.core.network.model.OrderList;
 import com.kin.ecosystem.core.util.ErrorUtil;
+import com.kin.ecosystem.core.util.StringUtil;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -169,7 +170,8 @@ public class OrderRepository implements OrderDataSource {
 	}
 
 	@Override
-	public void submitSpendOrder(@NonNull final String offerID, @Nullable String transaction, @NonNull final String orderID,
+	public void submitSpendOrder(@NonNull final String offerID, @Nullable String transaction,
+		@NonNull final String orderID,
 		@Nullable final KinCallback<Order> callback) {
 		listenForCompletedPayment();
 		remoteData.submitSpendOrder(transaction, orderID, createSubmitOrderCallback(callback, orderID, offerID));
@@ -188,12 +190,11 @@ public class OrderRepository implements OrderDataSource {
 					@Override
 					public void onChanged(Payment payment) {
 						if (!payment.isSucceed()) {
-							BlockchainException blockchainException = ErrorUtil
-								.getBlockchainException(payment.getException());
+							BlockchainException blockchainException = ErrorUtil.getBlockchainException(payment.getException());
 							final Error error = new Error("Transaction failed", blockchainException.getMessage(),
 								blockchainException.getCode());
 							final Body body = new Body().error(error);
-							changeOrder(payment.getOrderID(), body, null);
+							changeOrder(payment.getOrderID(), body);
 						}
 
 						sendEarnPaymentConfirmed(payment);
@@ -233,7 +234,8 @@ public class OrderRepository implements OrderDataSource {
 		}
 	}
 
-	private Callback<Order, ApiException> createSubmitOrderCallback(final KinCallback<Order> callback, final String orderID, final String offerID) {
+	private Callback<Order, ApiException> createSubmitOrderCallback(final KinCallback<Order> callback,
+		final String orderID, final String offerID) {
 		return new Callback<Order, ApiException>() {
 			@Override
 			public void onResponse(Order response) {
@@ -246,8 +248,8 @@ public class OrderRepository implements OrderDataSource {
 
 			@Override
 			public void onFailure(ApiException e) {
-				getOrderWatcher().postValue(
-					new Order().orderId(orderID).offerId(offerID).status(Status.FAILED).error(e.getResponseBody()));
+				//TODO should not be executed at all, the order is not pending
+				getOrderWatcher().postValue(new Order().orderId(orderID).offerId(offerID).status(Status.FAILED).error(e.getResponseBody()));
 				removeCachedOpenOrderByID(orderID);
 				if (callback != null) {
 					callback.onFailure(ErrorUtil.fromApiException(e));
@@ -263,18 +265,24 @@ public class OrderRepository implements OrderDataSource {
 
 	private void sendSpendOrderCompleted(Order order) {
 		if (order.getOfferType() == OfferType.SPEND && order.getOrigin() == Origin.MARKETPLACE) {
-			if (order.getStatus() == Status.COMPLETED) {
-				double amount = (double) order.getAmount();
-				eventLogger.send(SpendOrderCompleted
-					.create(order.getOfferId(), order.getOrderId(), false,
+			switch (order.getStatus()) {
+				case PENDING:
+					break;
+				case COMPLETED:
+					double amount = (double) order.getAmount();
+					eventLogger.send(SpendOrderCompleted.create(order.getOfferId(), order.getOrderId(), false,
 						SpendOrderCompleted.Origin.MARKETPLACE, amount));
-			} else {
-				String reason = "Timed out";
-				if (order.getError() != null) {
-					reason = order.getError().getMessage();
-				}
-				eventLogger.send(SpendOrderFailed.create(reason, order.getOfferId(), order.getOrderId(), false,
-					SpendOrderFailed.Origin.MARKETPLACE));
+					break;
+				case DELAYED:
+					break;
+				case FAILED:
+					String reason = "Timed out";
+					if (order.getError() != null && !StringUtil.isEmpty(order.getError().getMessage())) {
+						reason = order.getError().getMessage();
+					}
+					eventLogger.send(SpendOrderFailed.create(reason, order.getOfferId(), order.getOrderId(), false,
+						SpendOrderFailed.Origin.MARKETPLACE));
+					break;
 			}
 		}
 	}
@@ -334,10 +342,9 @@ public class OrderRepository implements OrderDataSource {
 			new ExternalSpendOrderCallbacks() {
 
 				@Override
-				public void onTransactionFailed(final OpenOrder openOrder, final KinEcosystemException exception) {
-					final String orderId = openOrder.getId();
+				public void onTransactionFailed(final String offerId, final String orderId, final KinEcosystemException exception) {
 					removeCachedOpenOrderByID(orderId);
-					handleOnFailure(exception, openOrder.getOfferId(), orderId);
+					handleOnFailure(offerId, orderId, exception);
 				}
 
 				@Override
@@ -359,24 +366,16 @@ public class OrderRepository implements OrderDataSource {
 				}
 
 				@Override
-				public void onOrderFailed(KinEcosystemException exception, OpenOrder openOrder) {
-					if (openOrder != null) { // did not fail before submit
+				public void onOrderFailed(final String offerId, final String orderId, KinEcosystemException exception) {
+					if (!StringUtil.isEmpty(orderId)) { // did not fail before submit
 						decrementCount();
 					}
-					handleOnFailure(exception, getOfferId(openOrder), getOrderId(openOrder));
+					handleOnFailure(offerId, orderId, exception);
 				}
 
-				private void handleOnFailure(KinEcosystemException exception, String offerId, String orderId) {
-					String reason = "";
-					if (exception != null) {
-						if (exception.getCause() != null) {
-							reason = exception.getCause().getMessage();
-						} else {
-							reason = exception.getMessage();
-						}
-					}
-					eventLogger.send(
-						SpendOrderFailed.create(reason, offerId, orderId, true, SpendOrderFailed.Origin.EXTERNAL));
+				private void handleOnFailure(final String offerId, final String orderId, KinEcosystemException exception) {
+					eventLogger.send(SpendOrderFailed
+						.create(exception.getMessage(), offerId, orderId, true, SpendOrderFailed.Origin.EXTERNAL));
 
 					if (callback != null) {
 						callback.onFailure(exception);
@@ -386,37 +385,23 @@ public class OrderRepository implements OrderDataSource {
 			}).start();
 	}
 
-	private String getOrderId(OpenOrder openOrder) {
-		return openOrder != null ? openOrder.getId() : "null";
-	}
-
-	private String getOfferId(OpenOrder openOrder) {
-		return openOrder != null ? openOrder.getOfferId() : "null";
-	}
-
 	/**
 	 * Update server with the relevant Body when an error occurred
 	 * or something that the server should know about happened.
 	 *
 	 * @param orderID the Order id that you refer to
 	 * @param body content with the relevant {@link Error}
-	 * @param kinCallback callback to receive the response from server, can be null.
 	 */
-	private void changeOrder(@NonNull String orderID, @NonNull Body body,
-		@Nullable final KinCallback<Order> kinCallback) {
+	private void changeOrder(@NonNull String orderID, @NonNull Body body) {
 		remoteData.changeOrder(orderID, body, new Callback<Order, ApiException>() {
 			@Override
 			public void onResponse(Order response) {
-				if (kinCallback != null) {
-					kinCallback.onResponse(response);
-				}
+				// no-op
 			}
 
 			@Override
 			public void onFailure(ApiException error) {
-				if (kinCallback != null) {
-					kinCallback.onFailure(ErrorUtil.fromApiException(error));
-				}
+				// no-op
 			}
 		});
 	}
@@ -437,19 +422,18 @@ public class OrderRepository implements OrderDataSource {
 			}
 
 			@Override
-			public void onOrderFailed(KinEcosystemException exception, OpenOrder openOrder) {
-				if (openOrder != null) { // did not fail before submit
+			public void onOrderFailed(final String offerId, final String orderId, KinEcosystemException exception) {
+				if (!StringUtil.isEmpty(orderId)) { // did not fail before submit
 					decrementCount();
 				}
-				handleOnFailure(exception, getOfferId(openOrder), getOrderId(openOrder));
+				handleOnFailure(exception, offerId, orderId);
 			}
 
 			private void handleOnFailure(KinEcosystemException exception, final String offerId, final String orderId) {
 				if (callback != null) {
 					callback.onFailure(exception);
 				}
-				eventLogger.send(
-					EarnOrderFailed.create(exception.getMessage(), offerId, orderId, EarnOrderFailed.Origin.EXTERNAL));
+				eventLogger.send(EarnOrderFailed.create(exception.getMessage(), offerId, orderId, EarnOrderFailed.Origin.EXTERNAL));
 			}
 		}).start();
 	}
@@ -465,7 +449,7 @@ public class OrderRepository implements OrderDataSource {
 	public void addOrderObserver(@NonNull Observer<Order> observer) {
 		getOrderWatcher().addObserver(observer);
 		final Order currentOrder = getOrderWatcher().getValue();
-		if(currentOrder != null) {
+		if (currentOrder != null) {
 			observer.onChanged(currentOrder);
 		}
 	}
@@ -485,9 +469,8 @@ public class OrderRepository implements OrderDataSource {
 
 			@Override
 			public void onFailure(Void t) {
-				callback
-					.onFailure(ErrorUtil
-						.getClientException(ClientException.INTERNAL_INCONSISTENCY, new DataNotAvailableException()));
+				callback.onFailure(
+					ErrorUtil.getClientException(ClientException.INTERNAL_INCONSISTENCY, new DataNotAvailableException()));
 			}
 		});
 	}

--- a/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/ErrorUtil.java
@@ -65,10 +65,12 @@ public class ErrorUtil {
 					if (error != null) {
 						switch (error.getCode()) {
 							case ERROR_CODE_NO_SUCH_USER:
-								return new ServiceException(ServiceException.USER_NOT_FOUND, getMessageOrDefault(error, ACCOUNT_NOT_FOUND), apiException);
+								return new ServiceException(ServiceException.USER_NOT_FOUND,
+									getMessage(error, ACCOUNT_NOT_FOUND), apiException);
 
 							case ERROR_CODE_USER_HAS_NO_WALLET:
-								return new ServiceException(ServiceException.USER_HAS_NO_WALLET, getMessageOrDefault(error, ACCOUNT_HAS_NO_WALLET), apiException);
+								return new ServiceException(ServiceException.USER_HAS_NO_WALLET,
+									getMessage(error, ACCOUNT_HAS_NO_WALLET), apiException);
 						}
 					}
 				case ERROR_CODE_CONFLICT:
@@ -76,18 +78,20 @@ public class ErrorUtil {
 				case ERROR_CODE_TRANSACTION_FAILED_ERROR:
 					if (error != null) {
 						return new ServiceException(ServiceException.SERVICE_ERROR,
-							getMessageOrDefault(error, THE_ECOSYSTEM_SERVER_RETURNED_AN_ERROR), apiException);
+							getMessage(error, THE_ECOSYSTEM_SERVER_RETURNED_AN_ERROR), apiException);
 					}
 					return createUnknownServiceException(apiException);
 				case ERROR_CODE_GONE:
 					if (error != null) {
 						if (error.getCode() == ERROR_CODE_BLOCKCHAIN_ENDPOINT_CHANGED) {
-							return new ServiceException(ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED, MIGRATION_NEEDED, apiException);
+							return new ServiceException(ServiceException.BLOCKCHAIN_ENDPOINT_CHANGED, MIGRATION_NEEDED,
+								apiException);
 						}
 					}
 					return createUnknownServiceException(apiException, error);
 				case ERROR_CODE_REQUEST_TIMEOUT:
-					return new ServiceException(ServiceException.TIMEOUT_ERROR, getMessageOrDefault(error, THE_OPERATION_TIMED_OUT), apiException);
+					return new ServiceException(ServiceException.TIMEOUT_ERROR,
+						getMessage(error, THE_OPERATION_TIMED_OUT), apiException);
 				case ClientException.INTERNAL_INCONSISTENCY:
 					return new ClientException(ClientException.INTERNAL_INCONSISTENCY, THE_OPERATION_TIMED_OUT,
 						apiException);
@@ -99,12 +103,13 @@ public class ErrorUtil {
 		}
 	}
 
-	private static KinEcosystemException createUnknownServiceException(@Nullable Throwable throwable) {
+	private static KinEcosystemException createUnknownServiceException(@Nullable ApiException throwable) {
 		return createUnknownServiceException(throwable, null);
 	}
 
-	private static KinEcosystemException createUnknownServiceException(@Nullable Throwable throwable, @Nullable Error error) {
-		String msg = getMessage(throwable);
+	private static KinEcosystemException createUnknownServiceException(@Nullable ApiException throwable,
+		@Nullable Error error) {
+		String msg = getMessage(throwable, "Unknown or null ApiException was thrown");
 
 		if (error != null) {
 			msg += " (" + error.getCode() + ")";
@@ -113,17 +118,18 @@ public class ErrorUtil {
 		return new ServiceException(ServiceException.SERVICE_ERROR, msg, throwable);
 	}
 
-	private static String getMessageOrDefault(Error error, final String defaultMsg) {
+	private static String getMessage(Error error, final String defaultMsg) {
 		return error != null && !StringUtil.isEmpty(error.getMessage()) ? error.getMessage() : defaultMsg;
 	}
 
-	private static String getMessage(Throwable throwable) {
-		return (throwable != null && throwable.getMessage() != null) ? throwable.getMessage() : getCauseOrDefault(throwable, ECOSYSTEM_SDK_ENCOUNTERED_AN_UNEXPECTED_ERROR);
+	public static String getMessage(Throwable throwable, final String defaultMsg) {
+		return (throwable != null && !StringUtil.isEmpty(throwable.getMessage())) ? throwable.getMessage()
+			: getCauseOrDefault(throwable, defaultMsg);
 	}
 
 	private static String getCauseOrDefault(Throwable throwable, final String defaultMsg) {
-		return (throwable != null && throwable.getCause() != null && throwable.getCause().getMessage() != null)
-			? throwable.getCause().getMessage() : defaultMsg ;
+		return (throwable != null && throwable.getCause() != null && !StringUtil
+			.isEmpty(throwable.getCause().getMessage())) ? throwable.getCause().getMessage() : defaultMsg;
 	}
 
 	public static ApiException createOrderTimeoutException() {
@@ -154,10 +160,15 @@ public class ErrorUtil {
 				FAILED_TO_ACTIVATE_ON_THE_BLOCKCHAIN_NETWORK, error);
 		} else {
 			exception = new BlockchainException(KinEcosystemException.UNKNOWN,
-				BLOCKCHAIN_ENCOUNTERED_AN_UNEXPECTED_ERROR, error);
+				getMessage(error, BLOCKCHAIN_ENCOUNTERED_AN_UNEXPECTED_ERROR), error);
 		}
 
 		return exception;
+	}
+
+	public static BlockchainException createMigrationFailedException(Exception error) {
+		final String errorMsg = getMessage(error, "Migration Failed");
+		return new BlockchainException(BlockchainException.MIGRATION_FAILED, errorMsg, error);
 	}
 
 	@SuppressLint("DefaultLocale")
@@ -181,8 +192,7 @@ public class ErrorUtil {
 			case ClientException.INTERNAL_INCONSISTENCY:
 			default:
 				exception = new ClientException(ClientException.INTERNAL_INCONSISTENCY,
-					ECOSYSTEM_SDK_ENCOUNTERED_AN_UNEXPECTED_ERROR,
-					e);
+					getMessage(e, ECOSYSTEM_SDK_ENCOUNTERED_AN_UNEXPECTED_ERROR), e);
 		}
 
 		return exception;

--- a/core/src/main/java/com/kin/ecosystem/core/util/JwtDecoder.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/JwtDecoder.java
@@ -4,6 +4,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 import com.kin.ecosystem.core.data.auth.JwtBody;
+import com.kin.ecosystem.core.data.order.OfferJwtBody;
+import com.kin.ecosystem.core.network.model.Offer.OfferType;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -12,6 +14,13 @@ public class JwtDecoder {
 	private static final String ISS_KEY = "iss";
 	private static final String USER_ID_KEY = "user_id";
 	private static final String DEVICE_ID_KEY = "device_id";
+
+	private static final String OFFER_OBJECT_KEY = "offer";
+	private static final String SUB_KEY = "sub";
+	private static final String ID_KEY = "id";
+
+
+
 	private static final int JWT_SPLIT_PARTS_SIZE = 3;
 
 	@Nullable
@@ -25,6 +34,19 @@ public class JwtDecoder {
 		return new JwtBody(object.getString(ISS_KEY),
 			object.getString(USER_ID_KEY),
 			object.getString(DEVICE_ID_KEY));
+	}
+
+	@Nullable
+	public static OfferJwtBody getOfferJwtBody(@NonNull String jwt) throws JSONException, IllegalArgumentException {
+		String body = decodeJwtBody(jwt);
+		if (StringUtil.isEmpty(body)) {
+			return null;
+		}
+
+		JSONObject object = new JSONObject(body);
+		final OfferType type = OfferType.fromValue(object.getString(SUB_KEY));
+		final String offerId = object.getJSONObject(OFFER_OBJECT_KEY).getString(ID_KEY);
+		return new OfferJwtBody(offerId, type);
 	}
 
 	@Nullable

--- a/core/src/main/java/com/kin/ecosystem/core/util/StringUtil.java
+++ b/core/src/main/java/com/kin/ecosystem/core/util/StringUtil.java
@@ -58,4 +58,8 @@ public class StringUtil {
 	public static boolean isEmpty(String text) {
 		return text == null || text.isEmpty();
 	}
+
+	public static String safeGuardNullString(String text) {
+		return isEmpty(text) ? "null" : text;
+	}
 }

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalEarnOrderCallTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalEarnOrderCallTest.kt
@@ -97,6 +97,33 @@ class ExternalEarnOrderCallTest : BaseTestClass() {
 		}
 	}
 
+	@Test
+	fun `run kin3 happy flow to completion`() {
+		whenever(blockchainSource.blockchainVersion).thenReturn(KinSdkVersion.NEW_KIN_SDK)
+		externalEarnOrderCall.run()
+		val paymentCaptor = argumentCaptor<Observer<Payment>>()
+		inOrder(orderDataSource, blockchainSource, eventLogger, externalOrderCallbacks).apply {
+			verify(orderDataSource).createExternalOrderSync(orderJwt)
+			verify(eventLogger).send(any<EarnOrderCreationReceived>())
+			verify(blockchainSource).addPaymentObservable(paymentCaptor.capture())
+			verify(blockchainSource).blockchainVersion
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).submitEarnOrder(any(), isNull(), any(), capture())
+				firstValue.onResponse(order)
+			}
+			verify(eventLogger).send(any<EarnOrderCompletionSubmitted>())
+			paymentCaptor.firstValue.onChanged(payment)
+			verify(blockchainSource).removePaymentObserver(any())
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).getOrder(any(), capture())
+				whenever(order.status).doReturn(Order.Status.COMPLETED)
+				firstValue.onResponse(order)
+
+			}
+			verify(externalOrderCallbacks).onOrderConfirmed(jwtBodyPaymentConfirmationResult.jwt, order)
+		}
+	}
+
 	companion object {
 		private const val orderJwt = "eyJraWQiOiJyczUxMl8xIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NTkxMzIzNzYsImlzcyI6InNtcGwiLCJleHAiOjE1NTkyMjIzNzYsInN1YiI6ImVhcm4iLCJvZmZlciI6eyJhbW91bnQiOjEwLCJpZCI6IjE4MTkwMCJ9LCJyZWNpcGllbnQiOnsiZGVzY3JpcHRpb24iOiJVcGxvYWQgcHJvZmlsZSBwaWN0dXJlIiwiZGV2aWNlX2lkIjoiNTNmNmM2Zjc5NjEzMWY0NiIsInRpdGxlIjoiUmVjZWl2ZWQgS2luIGZyb20gQXZpc2h5IiwidXNlcl9pZCI6InVzZXJfMTQxNzQ5In19.bY_c-mpDzUPNKOajfnAH4To1-9-tl_IekWHVeCSKMByF3dTUbywu4bOe2drlbX4Grd29fb538TlBCaZSMU9ask7LhVIf7YPoiU-PfkAoX4OWByyKTRp_gVRtsee560O26G-7Bh-5l524mGAJgYsEkvMsojVLcSYwZ9HMZTlVurM"
 		private const val offerId = "181900"

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalEarnOrderCallTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalEarnOrderCallTest.kt
@@ -1,0 +1,107 @@
+package com.kin.ecosystem.core.data.order
+
+import com.kin.ecosystem.common.KinCallback
+import com.kin.ecosystem.common.Observer
+import com.kin.ecosystem.core.bi.EventLogger
+import com.kin.ecosystem.core.bi.events.EarnOrderCompletionSubmitted
+import com.kin.ecosystem.core.bi.events.EarnOrderCreationReceived
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource
+import com.kin.ecosystem.core.data.blockchain.Payment
+import com.kin.ecosystem.core.network.model.BlockchainData
+import com.kin.ecosystem.core.network.model.JWTBodyPaymentConfirmationResult
+import com.kin.ecosystem.core.network.model.OpenOrder
+import com.kin.ecosystem.core.network.model.Order
+import com.nhaarman.mockitokotlin2.*
+import kin.ecosystem.test.base.BaseTestClass
+import kin.sdk.migration.common.KinSdkVersion
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.math.BigDecimal
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class ExternalEarnOrderCallTest : BaseTestClass() {
+
+	private val orderDataSource: OrderDataSource = mock {
+		on { createExternalOrderSync(any()) } doAnswer { openOrder}
+	}
+	private val blockchainSource: BlockchainSource = mock {
+		on { blockchainVersion } doAnswer { KinSdkVersion.OLD_KIN_SDK }
+	}
+	private val eventLogger: EventLogger = mock()
+	private val externalOrderCallbacks: CreateExternalOrderCall.ExternalOrderCallbacks = mock()
+
+	private val openOrder: OpenOrder = mock {
+		on { offerId } doAnswer  { offerId }
+		on { id } doAnswer { orderId }
+		on { amount } doAnswer { 10 }
+		on { blockchainData } doAnswer { blockchainData }
+	}
+
+	private val blockchainData: BlockchainData = mock {
+		on { recipientAddress } doAnswer { "some_address" }
+	}
+
+	private val order: Order = mock {
+		on { orderId } doAnswer { orderId }
+		on { offerId } doAnswer { offerId }
+		on { result } doAnswer { jwtBodyPaymentConfirmationResult }
+	}
+
+	private val payment: Payment = mock {
+		on { orderID } doAnswer { orderId }
+		on { isSucceed } doAnswer { true }
+		on { transactionID } doAnswer { transactionId }
+		on { type } doAnswer { Payment.EARN }
+	}
+
+	private val jwtBodyPaymentConfirmationResult: JWTBodyPaymentConfirmationResult = mock {
+		on { jwt } doAnswer { "jwt_confirmation" }
+	}
+
+
+	private lateinit var externalEarnOrderCall: ExternalEarnOrderCall
+
+	@Before
+	override fun setUp() {
+		super.setUp()
+		externalEarnOrderCall = ExternalEarnOrderCall(orderDataSource, blockchainSource, orderJwt, eventLogger, externalOrderCallbacks)
+	}
+
+	@Test
+	fun `run kin2 happy flow to completion`() {
+		externalEarnOrderCall.run()
+		val paymentCaptor = argumentCaptor<Observer<Payment>>()
+		inOrder(orderDataSource, blockchainSource, eventLogger, externalOrderCallbacks).apply {
+			verify(orderDataSource).createExternalOrderSync(orderJwt)
+			verify(eventLogger).send(any<EarnOrderCreationReceived>())
+			verify(blockchainSource).addPaymentObservable(paymentCaptor.capture())
+			verify(blockchainSource).blockchainVersion
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).submitEarnOrder(any(), isNull(), any(), capture())
+				firstValue.onResponse(order)
+			}
+			verify(eventLogger).send(any<EarnOrderCompletionSubmitted>())
+			paymentCaptor.firstValue.onChanged(payment)
+			verify(blockchainSource).removePaymentObserver(any())
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).getOrder(any(), capture())
+				whenever(order.status).doReturn(Order.Status.COMPLETED)
+				firstValue.onResponse(order)
+
+			}
+			verify(externalOrderCallbacks).onOrderConfirmed(jwtBodyPaymentConfirmationResult.jwt, order)
+		}
+	}
+
+	companion object {
+		private const val orderJwt = "eyJraWQiOiJyczUxMl8xIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NTkxMzIzNzYsImlzcyI6InNtcGwiLCJleHAiOjE1NTkyMjIzNzYsInN1YiI6ImVhcm4iLCJvZmZlciI6eyJhbW91bnQiOjEwLCJpZCI6IjE4MTkwMCJ9LCJyZWNpcGllbnQiOnsiZGVzY3JpcHRpb24iOiJVcGxvYWQgcHJvZmlsZSBwaWN0dXJlIiwiZGV2aWNlX2lkIjoiNTNmNmM2Zjc5NjEzMWY0NiIsInRpdGxlIjoiUmVjZWl2ZWQgS2luIGZyb20gQXZpc2h5IiwidXNlcl9pZCI6InVzZXJfMTQxNzQ5In19.bY_c-mpDzUPNKOajfnAH4To1-9-tl_IekWHVeCSKMByF3dTUbywu4bOe2drlbX4Grd29fb538TlBCaZSMU9ask7LhVIf7YPoiU-PfkAoX4OWByyKTRp_gVRtsee560O26G-7Bh-5l524mGAJgYsEkvMsojVLcSYwZ9HMZTlVurM"
+		private const val offerId = "181900"
+		private const val orderId = "123"
+		private const val transactionId = "some_transaction_id"
+
+	}
+}

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalSpendOrderCallTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalSpendOrderCallTest.kt
@@ -1,0 +1,116 @@
+package com.kin.ecosystem.core.data.order
+
+import com.kin.ecosystem.common.KinCallback
+import com.kin.ecosystem.common.Observer
+import com.kin.ecosystem.common.model.Balance
+import com.kin.ecosystem.core.bi.EventLogger
+import com.kin.ecosystem.core.bi.events.SpendOrderCompletionSubmitted
+import com.kin.ecosystem.core.bi.events.SpendOrderCreationReceived
+import com.kin.ecosystem.core.data.blockchain.BlockchainSource
+import com.kin.ecosystem.core.data.blockchain.Payment
+import com.kin.ecosystem.core.network.model.BlockchainData
+import com.kin.ecosystem.core.network.model.JWTBodyPaymentConfirmationResult
+import com.kin.ecosystem.core.network.model.OpenOrder
+import com.kin.ecosystem.core.network.model.Order
+import com.nhaarman.mockitokotlin2.*
+import kin.ecosystem.test.base.BaseTestClass
+import kin.sdk.migration.common.KinSdkVersion
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.math.BigDecimal
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class ExternalSpendOrderCallTest : BaseTestClass() {
+
+	private val orderDataSource: OrderDataSource = mock {
+		on { createExternalOrderSync(any()) } doAnswer { openOrder}
+	}
+	private val blockchainSource: BlockchainSource = mock {
+		on { blockchainVersion } doAnswer { KinSdkVersion.OLD_KIN_SDK }
+		on { balance } doAnswer { balance }
+	}
+
+	private val balance: Balance = mock {
+		on { amount } doAnswer { BigDecimal(5000) }
+	}
+
+	private val eventLogger: EventLogger = mock()
+	private val externalOrderCallbacks: CreateExternalOrderCall.ExternalSpendOrderCallbacks = mock()
+
+	private val openOrder: OpenOrder = mock {
+		on { offerId } doAnswer  { offerId }
+		on { id } doAnswer { orderId }
+		on { amount } doAnswer { 10 }
+		on { blockchainData } doAnswer { blockchainData }
+	}
+
+	private val blockchainData: BlockchainData = mock {
+		on { recipientAddress } doAnswer { "some_address" }
+	}
+
+	private val order: Order = mock {
+		on { orderId } doAnswer { orderId }
+		on { offerId } doAnswer { offerId }
+		on { result } doAnswer { jwtBodyPaymentConfirmationResult }
+	}
+
+	private val payment: Payment = mock {
+		on { orderID } doAnswer { orderId }
+		on { isSucceed } doAnswer { true }
+		on { transactionID } doAnswer { transactionId }
+		on { type } doAnswer { Payment.SPEND }
+	}
+
+	private val jwtBodyPaymentConfirmationResult: JWTBodyPaymentConfirmationResult = mock {
+		on { jwt } doAnswer { "jwt_confirmation" }
+	}
+
+
+	private lateinit var externalEarnOrderCall: ExternalSpendOrderCall
+
+	@Before
+	override fun setUp() {
+		super.setUp()
+		externalEarnOrderCall = ExternalSpendOrderCall(orderDataSource, blockchainSource, orderJwt, eventLogger, externalOrderCallbacks)
+	}
+
+	@Test
+	fun `run kin2 happy flow to completion`() {
+		externalEarnOrderCall.run()
+		val paymentCaptor = argumentCaptor<Observer<Payment>>()
+		inOrder(orderDataSource, blockchainSource, eventLogger, externalOrderCallbacks).apply {
+			verify(orderDataSource).createExternalOrderSync(orderJwt)
+			verify(eventLogger).send(any<SpendOrderCreationReceived>())
+			verify(blockchainSource).balance
+			verify(blockchainSource).addPaymentObservable(paymentCaptor.capture())
+			verify(blockchainSource).blockchainVersion
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).submitSpendOrder(any(), isNull(), any(), capture())
+				firstValue.onResponse(order)
+			}
+
+			verify(eventLogger).send(any<SpendOrderCompletionSubmitted>())
+			verify(blockchainSource).sendTransaction(any(), any(), any(), any())
+			paymentCaptor.firstValue.onChanged(payment)
+			verify(blockchainSource).removePaymentObserver(any())
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).getOrder(any(), capture())
+				whenever(order.status).doReturn(Order.Status.COMPLETED)
+				firstValue.onResponse(order)
+			}
+			verify(externalOrderCallbacks).onOrderConfirmed(jwtBodyPaymentConfirmationResult.jwt, order)
+		}
+	}
+
+	companion object {
+		private const val orderJwt = "eyJraWQiOiJyczUxMl8xIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NTkxMzIzNzYsImlzcyI6InNtcGwiLCJleHAiOjE1NTkyMjIzNzYsInN1YiI6ImVhcm4iLCJvZmZlciI6eyJhbW91bnQiOjEwLCJpZCI6IjE4MTkwMCJ9LCJyZWNpcGllbnQiOnsiZGVzY3JpcHRpb24iOiJVcGxvYWQgcHJvZmlsZSBwaWN0dXJlIiwiZGV2aWNlX2lkIjoiNTNmNmM2Zjc5NjEzMWY0NiIsInRpdGxlIjoiUmVjZWl2ZWQgS2luIGZyb20gQXZpc2h5IiwidXNlcl9pZCI6InVzZXJfMTQxNzQ5In19.bY_c-mpDzUPNKOajfnAH4To1-9-tl_IekWHVeCSKMByF3dTUbywu4bOe2drlbX4Grd29fb538TlBCaZSMU9ask7LhVIf7YPoiU-PfkAoX4OWByyKTRp_gVRtsee560O26G-7Bh-5l524mGAJgYsEkvMsojVLcSYwZ9HMZTlVurM"
+		private const val offerId = "181900"
+		private const val orderId = "123"
+		private const val transactionId = "some_transaction_id"
+
+	}
+}

--- a/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalSpendOrderCallTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/data/order/ExternalSpendOrderCallTest.kt
@@ -106,6 +106,37 @@ class ExternalSpendOrderCallTest : BaseTestClass() {
 		}
 	}
 
+	@Test
+	fun `run kin3 happy flow to completion`() {
+		whenever(blockchainSource.blockchainVersion).thenReturn(KinSdkVersion.NEW_KIN_SDK)
+		externalEarnOrderCall.run()
+		val paymentCaptor = argumentCaptor<Observer<Payment>>()
+		val signTransactionCaptor = argumentCaptor<BlockchainSource.SignTransactionListener>()
+		inOrder(orderDataSource, blockchainSource, eventLogger, externalOrderCallbacks).apply {
+			verify(orderDataSource).createExternalOrderSync(orderJwt)
+			verify(eventLogger).send(any<SpendOrderCreationReceived>())
+			verify(blockchainSource).balance
+			verify(blockchainSource).addPaymentObservable(paymentCaptor.capture())
+			verify(blockchainSource).blockchainVersion
+			verify(blockchainSource).signTransaction(any(), any(), any(), any(),signTransactionCaptor.capture())
+			signTransactionCaptor.firstValue.onTransactionSigned(transactionId)
+			verify(eventLogger).send(any<SpendOrderCompletionSubmitted>())
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).submitSpendOrder(any(), any(), any(), capture())
+				firstValue.onResponse(order)
+			}
+
+			paymentCaptor.firstValue.onChanged(payment)
+			verify(blockchainSource).removePaymentObserver(any())
+			argumentCaptor<KinCallback<Order>>().apply {
+				verify(orderDataSource).getOrder(any(), capture())
+				whenever(order.status).doReturn(Order.Status.COMPLETED)
+				firstValue.onResponse(order)
+			}
+			verify(externalOrderCallbacks).onOrderConfirmed(jwtBodyPaymentConfirmationResult.jwt, order)
+		}
+	}
+
 	companion object {
 		private const val orderJwt = "eyJraWQiOiJyczUxMl8xIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NTkxMzIzNzYsImlzcyI6InNtcGwiLCJleHAiOjE1NTkyMjIzNzYsInN1YiI6ImVhcm4iLCJvZmZlciI6eyJhbW91bnQiOjEwLCJpZCI6IjE4MTkwMCJ9LCJyZWNpcGllbnQiOnsiZGVzY3JpcHRpb24iOiJVcGxvYWQgcHJvZmlsZSBwaWN0dXJlIiwiZGV2aWNlX2lkIjoiNTNmNmM2Zjc5NjEzMWY0NiIsInRpdGxlIjoiUmVjZWl2ZWQgS2luIGZyb20gQXZpc2h5IiwidXNlcl9pZCI6InVzZXJfMTQxNzQ5In19.bY_c-mpDzUPNKOajfnAH4To1-9-tl_IekWHVeCSKMByF3dTUbywu4bOe2drlbX4Grd29fb538TlBCaZSMU9ask7LhVIf7YPoiU-PfkAoX4OWByyKTRp_gVRtsee560O26G-7Bh-5l524mGAJgYsEkvMsojVLcSYwZ9HMZTlVurM"
 		private const val offerId = "181900"

--- a/core/src/test/kotlin/com/kin/ecosystem/core/util/JwtDecoderTest.kt
+++ b/core/src/test/kotlin/com/kin/ecosystem/core/util/JwtDecoderTest.kt
@@ -1,5 +1,6 @@
 package com.kin.ecosystem.core.util
 
+import com.kin.ecosystem.core.network.model.Offer
 import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -13,13 +14,14 @@ import org.robolectric.annotation.Config
 class JwtDecoderTest {
 
     companion object {
-        const val TEST_JWT = "eyJraWQiOiJyczUxMl8wIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NDY1MTQ2ODEsImlzcyI6InRlc3QiLCJleHAiOjE1NDY2MDEwODEsInN1YiI6InJlZ2lzdGVyIiwidXNlcl9pZCI6IjY0MTkwZjA0LTdhNGUtNDMxYy1hZGE3LWJiZGJmZmRjMzM0MyIsImRldmljZV9pZCI6ImY3YWY2ODU5LTBiYzEtNDg1NS1iN2ViLWE2MDU4NDdiN2I5NSJ9.OyiOrkHpYiDy1B13uV26VDol2jQyTuIni3QfZxsXMtEQghV76CR17WxgpwF6rrbHOtrugV5eugqH9ZeDIvtGRhD13UY7koLXUghuI52Xn_WlNEcqfC2eULowc3SYVs1yYXprk0Mt1sW7BAuksnJDFYbcQmZQqWX1AFRtOrAla0Y"
-        const val WRONG_JWT = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MejLezWY6hjGgbIXkq6Qbvx_-q5vWaTR6qPiNHphvla-XaZD3up1DN6Ib5AEOVtuB3fC9l-0L36noK4qQA79lhpSK3gozXO6XPIcCp4C8MU_ACzGtYe7IwGnnK3Emr6IHQE0bpGinHX1Ak1pAuwJNawaQ6Nvmz2ozZPsyxmiwoo"
+        const val TEST_JWT_LOGIN = "eyJraWQiOiJyczUxMl8wIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NDY1MTQ2ODEsImlzcyI6InRlc3QiLCJleHAiOjE1NDY2MDEwODEsInN1YiI6InJlZ2lzdGVyIiwidXNlcl9pZCI6IjY0MTkwZjA0LTdhNGUtNDMxYy1hZGE3LWJiZGJmZmRjMzM0MyIsImRldmljZV9pZCI6ImY3YWY2ODU5LTBiYzEtNDg1NS1iN2ViLWE2MDU4NDdiN2I5NSJ9.OyiOrkHpYiDy1B13uV26VDol2jQyTuIni3QfZxsXMtEQghV76CR17WxgpwF6rrbHOtrugV5eugqH9ZeDIvtGRhD13UY7koLXUghuI52Xn_WlNEcqfC2eULowc3SYVs1yYXprk0Mt1sW7BAuksnJDFYbcQmZQqWX1AFRtOrAla0Y"
+        const val WRONG_JWT_LOGIN = "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MejLezWY6hjGgbIXkq6Qbvx_-q5vWaTR6qPiNHphvla-XaZD3up1DN6Ib5AEOVtuB3fC9l-0L36noK4qQA79lhpSK3gozXO6XPIcCp4C8MU_ACzGtYe7IwGnnK3Emr6IHQE0bpGinHX1Ak1pAuwJNawaQ6Nvmz2ozZPsyxmiwoo"
+        const val TEST_JWT_ORDER = "eyJraWQiOiJyczUxMl8xIiwidHlwIjoiand0IiwiYWxnIjoiUlM1MTIifQ.eyJpYXQiOjE1NTkxMzIzNzYsImlzcyI6InNtcGwiLCJleHAiOjE1NTkyMjIzNzYsInN1YiI6ImVhcm4iLCJvZmZlciI6eyJhbW91bnQiOjEwLCJpZCI6IjE4MTkwMCJ9LCJyZWNpcGllbnQiOnsiZGVzY3JpcHRpb24iOiJVcGxvYWQgcHJvZmlsZSBwaWN0dXJlIiwiZGV2aWNlX2lkIjoiNTNmNmM2Zjc5NjEzMWY0NiIsInRpdGxlIjoiUmVjZWl2ZWQgS2luIGZyb20gQXZpc2h5IiwidXNlcl9pZCI6InVzZXJfMTQxNzQ5In19.bY_c-mpDzUPNKOajfnAH4To1-9-tl_IekWHVeCSKMByF3dTUbywu4bOe2drlbX4Grd29fb538TlBCaZSMU9ask7LhVIf7YPoiU-PfkAoX4OWByyKTRp_gVRtsee560O26G-7Bh-5l524mGAJgYsEkvMsojVLcSYwZ9HMZTlVurM"
     }
 
     @Test
-    fun `decode jwt get correct attributes`() {
-        val body = JwtDecoder.getJwtBody(TEST_JWT)
+    fun `decode login jwt get correct attributes`() {
+        val body = JwtDecoder.getJwtBody(TEST_JWT_LOGIN)
         assertEquals("test", body?.appId)
         assertEquals("64190f04-7a4e-431c-ada7-bbdbffdc3343", body?.userId)
         assertEquals("f7af6859-0bc1-4855-b7eb-a605847b7b95", body?.deviceId)
@@ -32,11 +34,18 @@ class JwtDecoderTest {
 
     @Test(expected = JSONException::class)
     fun `jwt missing attrs, throw JSONException`() {
-        JwtDecoder.getJwtBody(WRONG_JWT)
+        JwtDecoder.getJwtBody(WRONG_JWT_LOGIN)
     }
 
     @Test
     fun `jwt too short not the jwt format, return null`() {
         assertNull(JwtDecoder.getJwtBody("jib"))
+    }
+
+    @Test
+    fun `decode order jwt get correct attributes`() {
+        val body = JwtDecoder.getOfferJwtBody(TEST_JWT_ORDER)
+        assertEquals("181900", body?.offerId)
+        assertEquals(Offer.OfferType.EARN, body?.type)
     }
 }

--- a/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
+++ b/sdk/src/main/java/com/kin/ecosystem/KinBlockchainVersionProvider.java
@@ -10,7 +10,7 @@ class KinBlockchainVersionProvider implements IKinVersionProvider {
 	private final BlockchainSource.Local local;
 	private final BlockchainSource.Remote remote;
 
-	public KinBlockchainVersionProvider(BlockchainSource.Local local, BlockchainSource.Remote remote) {
+	KinBlockchainVersionProvider(BlockchainSource.Local local, BlockchainSource.Remote remote) {
 		this.local = local;
 		this.remote = remote;
 	}


### PR DESCRIPTION
#### Main purpose:
Reduce the amount of black error reasons on login_failed and as well for native_earn/spend_failed events.
#### Technical description:
- Aligned all the exceptions to be `KinEcosystemException` and use `ErrorUtil` to get it.
- Refactored abit `CreateExternalOrderCall` so it will be more clear to read.
- Moved some of the logic to `ExternalEarnOrderCall` and `ExternalSpendOrderCall`
- Added unit test for those cases(only happy flow meantime)
#### Tests:
 - Added unit test for `ExternalEarnOrderCall` and `ExternalSpendOrderCall`
