### PR TITLE
ECO 1504/Disable RTL support

### DIFF
--- a/sdk/src/main/res/layout/kinecosystem_activity_main.xml
+++ b/sdk/src/main/res/layout/kinecosystem_activity_main.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
+    android:layoutDirection="ltr"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_weight="1"


### PR DESCRIPTION
#### Main purpose:
In case a phone's language is set to a language that is read from right to left our UI appears flipped and broken

#### Technical description:
* disable rtl support (Marketplace/ OrderHistory/ Settings)