### PR TITLE
ECO 1564/Disable RTL support (Restore/ Backup)

### DIFF
--- a/recovery/src/main/res/layout/kinrecovery_frgment_activity.xml
+++ b/recovery/src/main/res/layout/kinrecovery_frgment_activity.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layoutDirection="ltr"
     android:orientation="vertical"
     android:weightSum="1">
 


### PR DESCRIPTION
#### Main purpose:
In case a phone's language is set to a language that is read from right to left our UI appears flipped and broken.

#### Technical description:
* disable rtl support (Restore/ Backup)