### PR TITLE
Clear cache on logout

### DIFF
--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -424,12 +424,10 @@ public class Kin {
 	 */
 	public static void logout() throws ClientException {
 		checkInstanceNotNull();
-		if (isAccountLoggedIn.compareAndSet(true, false)) {
-			eventLogger.send(UserLogoutRequested.create());
-			Logger.log(new Log().withTag("Kin.java").text("logout").put("isAccountLoggedIn", isAccountLoggedIn));
-			AuthRepository.getInstance().logout();
-			clearCachedData();
-		}
+		eventLogger.send(UserLogoutRequested.create());
+		Logger.log(new Log().withTag("Kin.java").text("logout").put("isAccountLoggedIn", isAccountLoggedIn));
+		AuthRepository.getInstance().logout();
+		clearCachedData();
 	}
 
 	/**

--- a/sdk/src/main/java/com/kin/ecosystem/Kin.java
+++ b/sdk/src/main/java/com/kin/ecosystem/Kin.java
@@ -424,6 +424,7 @@ public class Kin {
 	 */
 	public static void logout() throws ClientException {
 		checkInstanceNotNull();
+		isAccountLoggedIn.set(false);
 		eventLogger.send(UserLogoutRequested.create());
 		Logger.log(new Log().withTag("Kin.java").text("logout").put("isAccountLoggedIn", isAccountLoggedIn));
 		AuthRepository.getInstance().logout();


### PR DESCRIPTION
#### Main purpose:
If userA call `AuthRepository.getInstance().getAccountInfo` successfully, his token info will be written into cache. But if `AuthRepository.getInstance().updateWalletAddress` or migrate methods get failure callback, the `sendLoginFailed` method is called and `isAccountLoggedIn` variable is false. When userA want to use another app account, the `Kin.logOut` method is invoked. But userA’s token info in cache is not cleared because of `isAccountLoggedIn` is false. Another app account will always use userA’s token to interactive with `api.kinmarketplace.com`. For the users who have the issue, they cannot use Kin anymore unless the previous account’s token is expired or they clear app data.

Closes #310 

#### Technical description:
* cleare cache always when logout
