### PR TITLE
ECO-1597/ crashes when trying to login back after internet loss

### DIFF
--- a/core/src/main/java/com/kin/ecosystem/core/data/auth/AuthRepository.java
+++ b/core/src/main/java/com/kin/ecosystem/core/data/auth/AuthRepository.java
@@ -207,8 +207,10 @@ public class AuthRepository implements AuthDataSource {
 
 	@Override
 	public void logout() {
-		final String token = cachedAuthToken.getToken();
-		remoteData.logout(token);
+		if (cachedAuthToken != null) {
+			final String token = cachedAuthToken.getToken();
+			remoteData.logout(token);
+		}
 
 		cachedAuthToken = null;
 		jwt = null;


### PR DESCRIPTION
#### Main purpose:
fix crash when trying to login back after internet loss

#### Technical description:
* avoid null exception on logout (cachedAuthToken)

